### PR TITLE
Submission Submit should not use hardcoded status "Submitted"

### DIFF
--- a/src/main/webapp/app/repo/submissionStatusRepo.js
+++ b/src/main/webapp/app/repo/submissionStatusRepo.js
@@ -1,4 +1,4 @@
-vireo.repo("SubmissionStatusRepo", function SubmissionStatusRepo() {
+vireo.repo("SubmissionStatusRepo", function SubmissionStatusRepo(WsApi) {
 
 	var submissionStatusRepo = this;
 
@@ -19,6 +19,14 @@ vireo.repo("SubmissionStatusRepo", function SubmissionStatusRepo() {
 		});
 		return foundStatus;
 	};
+
+    submissionStatusRepo.getDefault = function(state) {
+        angular.extend(submissionStatusRepo.mapping.default, {
+            'method': 'default/' + state
+        });
+
+        return WsApi.fetch(submissionStatusRepo.mapping.default);
+    };
 
 	return submissionStatusRepo;
 

--- a/src/main/webapp/tests/unit/models/submissionTest.js
+++ b/src/main/webapp/tests/unit/models/submissionTest.js
@@ -1,8 +1,8 @@
 describe('model: Submission', function () {
-    var model, q, rootScope, scope, ActionLog, FieldValue, FileService, Organization, WsApi;
+    var model, q, rootScope, scope, ActionLog, FieldValue, FileService, Organization, SubmissionStatusRepo, WsApi;
 
     var initializeVariables = function(settings) {
-        inject(function ($q, $rootScope, _ActionLog_, _FieldValue_, _FileService_ /*, _Organization_*/, _WsApi_) {
+        inject(function ($q, $rootScope, _ActionLog_, _FieldValue_, _FileService_ /*, _Organization_*/, _SubmissionStatusRepo_, _WsApi_) {
             q = $q;
             rootScope = $rootScope;
 
@@ -10,6 +10,7 @@ describe('model: Submission', function () {
             FieldValue = _FieldValue_;
             FileService = _FileService_;
             // Organization = _Organization_;
+            SubmissionStatusRepo = _SubmissionStatusRepo_;
             WsApi = _WsApi_;
         });
     };
@@ -579,9 +580,10 @@ describe('model: Submission', function () {
             expect(WsApi.fetch).toHaveBeenCalled();
         });
         it('submit should change the status', function () {
-            spyOn(model, "changeStatus");
+            spyOn(model, "changeStatus").and.callThrough();
 
             model.submit();
+            scope.$apply();
 
             expect(model.changeStatus).toHaveBeenCalled();
         });

--- a/src/main/webapp/tests/unit/repos/submissionStatusRepoTest.js
+++ b/src/main/webapp/tests/unit/repos/submissionStatusRepoTest.js
@@ -42,6 +42,10 @@ describe("service: submissionStatusRepo", function () {
             expect(repo.findByName).toBeDefined();
             expect(typeof repo.findByName).toEqual("function");
         });
+        it("getDefault should be defined", function () {
+            expect(repo.getDefault).toBeDefined();
+            expect(typeof repo.getDefault).toEqual("function");
+        });
     });
 
     describe("Do the repo methods work as expected", function () {
@@ -57,6 +61,14 @@ describe("service: submissionStatusRepo", function () {
             var response;
 
             response = repo.findByName("mock");
+            scope.$digest();
+
+            // TODO
+        });
+        it("getDefault should return a submission status", function () {
+            var response;
+
+            response = repo.getDefault("SUBMITTED");
             scope.$digest();
 
             // TODO


### PR DESCRIPTION
This provides a quick solution to the problem.
However, a more appropriate solution would be to create an end-point for "submit".
Creating a newer end-point is a more involved change and so I opted for this quick simple fix at this time.

resolves #44