### PR TITLE
Submission Submit should not use hardcoded status "Submitted"

### DIFF
--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -622,6 +622,12 @@ var apiMapping = {
             'controller': 'submission',
             'method': 'change-status'
         },
+        submit: {
+            'endpoint': '/private/queue',
+            'controller': 'submission',
+            'method': 'submit',
+            'httpMethod': 'POST'
+        },
         publish: {
             'endpoint': '/private/queue',
             'controller': 'submission',

--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -1,8 +1,10 @@
-var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organization, EmailRecipient, EmailRecipientType, WsApi) {
+var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organization, EmailRecipient, EmailRecipientType, SubmissionRepo, WsApi) {
 
     return function Submission() {
 
         var submission = this;
+
+        var submissionRepo = SubmissionRepo;
 
         submission.isValid = false;
 
@@ -575,7 +577,7 @@ var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organiza
         };
 
         submission.submit = function () {
-            return submission.changeStatus('Submitted');
+            return submissionRepo.submit(submission.id);
         };
 
         submission.setSubmissionDate = function (newDate) {

--- a/src/main/webapp/app/repo/submissionRepo.js
+++ b/src/main/webapp/app/repo/submissionRepo.js
@@ -67,6 +67,14 @@ vireo.repo("SubmissionRepo", function SubmissionRepo($q, FileService, Submission
         return promise;
     };
 
+    submissionRepo.submit = function (id) {
+        angular.extend(submissionRepo.mapping.submit, {
+            method: id + "/submit/"
+        });
+        var promise = WsApi.fetch(submissionRepo.mapping.submit);
+        return promise;
+    };
+
     return submissionRepo;
 
 });

--- a/src/main/webapp/app/repo/submissionStatusRepo.js
+++ b/src/main/webapp/app/repo/submissionStatusRepo.js
@@ -1,4 +1,4 @@
-vireo.repo("SubmissionStatusRepo", function SubmissionStatusRepo() {
+vireo.repo("SubmissionStatusRepo", function SubmissionStatusRepo(WsApi) {
 
 	var submissionStatusRepo = this;
 
@@ -19,6 +19,14 @@ vireo.repo("SubmissionStatusRepo", function SubmissionStatusRepo() {
 		});
 		return foundStatus;
 	};
+
+    submissionStatusRepo.getDefault = function(state) {
+        angular.extend(submissionStatusRepo.mapping.default, {
+            'method': 'default/' + state
+        });
+
+        return WsApi.fetch(submissionStatusRepo.mapping.default);
+    };
 
 	return submissionStatusRepo;
 

--- a/src/main/webapp/tests/unit/models/submissionTest.js
+++ b/src/main/webapp/tests/unit/models/submissionTest.js
@@ -1,8 +1,8 @@
 describe('model: Submission', function () {
-    var model, q, rootScope, scope, ActionLog, FieldValue, FileService, Organization, WsApi;
+    var model, q, rootScope, scope, ActionLog, FieldValue, FileService, Organization, SubmissionRepo, WsApi;
 
     var initializeVariables = function(settings) {
-        inject(function ($q, $rootScope, _ActionLog_, _FieldValue_, _FileService_ /*, _Organization_*/, _WsApi_) {
+        inject(function ($q, $rootScope, _ActionLog_, _FieldValue_, _FileService_ /*, _Organization_*/, _SubmissionRepo_, _WsApi_) {
             q = $q;
             rootScope = $rootScope;
 
@@ -10,6 +10,7 @@ describe('model: Submission', function () {
             FieldValue = _FieldValue_;
             FileService = _FileService_;
             // Organization = _Organization_;
+            SubmissionRepo = _SubmissionRepo_;
             WsApi = _WsApi_;
         });
     };
@@ -579,11 +580,11 @@ describe('model: Submission', function () {
             expect(WsApi.fetch).toHaveBeenCalled();
         });
         it('submit should change the status', function () {
-            spyOn(model, "changeStatus");
+            spyOn(SubmissionRepo, "submit").and.callThrough();
 
             model.submit();
 
-            expect(model.changeStatus).toHaveBeenCalled();
+            expect(SubmissionRepo.submit).toHaveBeenCalled();
         });
         // FIXME: asynchronous issues.
         /*it('submitCorrections should call WsApi', function () {

--- a/src/main/webapp/tests/unit/repos/submissionStatusRepoTest.js
+++ b/src/main/webapp/tests/unit/repos/submissionStatusRepoTest.js
@@ -42,6 +42,10 @@ describe("service: submissionStatusRepo", function () {
             expect(repo.findByName).toBeDefined();
             expect(typeof repo.findByName).toEqual("function");
         });
+        it("getDefault should be defined", function () {
+            expect(repo.getDefault).toBeDefined();
+            expect(typeof repo.getDefault).toEqual("function");
+        });
     });
 
     describe("Do the repo methods work as expected", function () {
@@ -57,6 +61,14 @@ describe("service: submissionStatusRepo", function () {
             var response;
 
             response = repo.findByName("mock");
+            scope.$digest();
+
+            // TODO
+        });
+        it("getDefault should return a submission status", function () {
+            var response;
+
+            response = repo.getDefault("SUBMITTED");
             scope.$digest();
 
             // TODO


### PR DESCRIPTION
Provide a new end-point called "submit" that will auto-discover the correct default state for "Submitted" and then perform the change-status in one go.

resolves #44