### PR TITLE
Improve Error Handling and Error Reporting for custom Submission Statuses

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -48,7 +48,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.tdl.vireo.exception.DepositException;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsExcception;
 import org.tdl.vireo.exception.SubmissionException;
-import org.tdl.vireo.exception.SubmissionStatusException;
 import org.tdl.vireo.model.CustomActionValue;
 import org.tdl.vireo.model.DepositLocation;
 import org.tdl.vireo.model.FieldValue;

--- a/src/main/java/org/tdl/vireo/controller/SubmissionStatusController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionStatusController.java
@@ -1,6 +1,5 @@
 package org.tdl.vireo.controller;
 
-import static edu.tamu.weaver.response.ApiStatus.ERROR;
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.CREATE;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.DELETE;
@@ -78,7 +77,7 @@ public class SubmissionStatusController {
     @PostMapping("/delete")
     @PreAuthorize("hasRole('MANAGER')")
     @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE) })
-    public ApiResponse deleteSubmissionStatus(@WeaverValidatedModel SubmissionStatus submissionStatus) {
+    public ApiResponse deleteSubmissionStatus(@WeaverValidatedModel @RequestBody SubmissionStatus submissionStatus) {
         submissionStatusRepo.delete(submissionStatus);
         submissionStatusRepo.flush();
 

--- a/src/main/java/org/tdl/vireo/controller/SubmissionStatusController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionStatusController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.tdl.vireo.exception.SubmissionStatusException;
 import org.tdl.vireo.model.SubmissionState;
 import org.tdl.vireo.model.SubmissionStatus;
 import org.tdl.vireo.model.repo.SubmissionStatusRepo;
@@ -81,12 +82,12 @@ public class SubmissionStatusController {
         submissionStatusRepo.delete(submissionStatus);
         submissionStatusRepo.flush();
 
-        if (!submissionStatusRepo.exists(submissionStatus.getId())) {
-            simpMessagingTemplate.convertAndSend("/channel/submission-status", new ApiResponse(SUCCESS, ApiAction.DELETE, submissionStatus));
-            return new ApiResponse(SUCCESS, ApiAction.DELETE, "Submission Status " + submissionStatus.getName() + " has been deleted!");
+        if (submissionStatusRepo.exists(submissionStatus.getId())) {
+            throw new SubmissionStatusException("Submission Status " + submissionStatus.getName() + " could not be deleted!");
         }
 
-        return new ApiResponse(ERROR, ApiAction.DELETE, "Submission Status " + submissionStatus.getName() + " could not be deleted!");
+        simpMessagingTemplate.convertAndSend("/channel/submission-status", new ApiResponse(SUCCESS, ApiAction.DELETE, submissionStatus));
+        return new ApiResponse(SUCCESS, ApiAction.DELETE, "Submission Status " + submissionStatus.getName() + " has been deleted!");
     }
 
 }

--- a/src/main/java/org/tdl/vireo/controller/advice/CustomResponseEntityExceptionHandler.java
+++ b/src/main/java/org/tdl/vireo/controller/advice/CustomResponseEntityExceptionHandler.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.tdl.vireo.exception.SubmissionException;
+import org.tdl.vireo.exception.SubmissionStatusException;
 import org.tdl.vireo.exception.SwordDepositException;
 
 import edu.tamu.weaver.response.ApiResponse;
@@ -35,6 +37,20 @@ public class CustomResponseEntityExceptionHandler extends ResponseEntityExceptio
     @ResponseBody
     public ApiResponse handleSwordDepositException(SwordDepositException exception) {
         logger.debug(exception.getMessage(), exception);
+        return new ApiResponse(ERROR, exception.getMessage());
+    }
+
+    @ExceptionHandler(SubmissionException.class)
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ApiResponse handleSubmissionException(SubmissionException exception) {
+        return new ApiResponse(ERROR, exception.getMessage());
+    }
+
+    @ExceptionHandler(SubmissionStatusException.class)
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ApiResponse handleSubmissionStatusException(SubmissionStatusException exception) {
         return new ApiResponse(ERROR, exception.getMessage());
     }
 

--- a/src/main/java/org/tdl/vireo/exception/SubmissionException.java
+++ b/src/main/java/org/tdl/vireo/exception/SubmissionException.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.exception;
+
+public class SubmissionException extends RuntimeException {
+
+    private static final long serialVersionUID = 1015567234853452869L;
+
+    public SubmissionException() {
+        super();
+    }
+
+    public SubmissionException(String message) {
+        super(message);
+    }
+
+    public SubmissionException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/exception/SubmissionStatusException.java
+++ b/src/main/java/org/tdl/vireo/exception/SubmissionStatusException.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.exception;
+
+public class SubmissionStatusException extends RuntimeException {
+
+    private static final long serialVersionUID = 7472398998406972054L;
+
+    public SubmissionStatusException() {
+        super();
+    }
+
+    public SubmissionStatusException(String message) {
+        super(message);
+    }
+
+    public SubmissionStatusException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -402,6 +402,7 @@
   <script src="filters/fieldValuePerProfile.js"></script>
   <script src="filters/trustHtml.js"></script>
   <script src="filters/readableFileSize.js"></script>
+  <script src="filters/withoutId.js"></script>
 
   <!-- Controllers -->
   <script src="controllers/abstractController.js"></script>

--- a/src/main/webapp/app/controllers/settings/submissionStatusController.js
+++ b/src/main/webapp/app/controllers/settings/submissionStatusController.js
@@ -96,6 +96,10 @@ vireo.controller("SubmissionStatusController", function ($controller, $scope, $q
             $scope.modalData.save();
         };
 
+        $scope.canRemoveSubmissionStatus = function (isDefault) {
+            return angular.isDefined(isDefault) && (isDefault === true || isDefault === "true");
+        };
+
         $scope.removeSubmissionStatus = function () {
             $scope.modalData.delete();
         };

--- a/src/main/webapp/app/controllers/settings/submissionStatusController.js
+++ b/src/main/webapp/app/controllers/settings/submissionStatusController.js
@@ -129,13 +129,15 @@ vireo.controller("SubmissionStatusController", function ($controller, $scope, $q
 
         $scope.dragControlListeners.orderChanged = function (event) {};
 
-        $scope.totalDefaultsForSubmissionState = function (submissionState) {
+        $scope.totalDefaultsForSubmissionState = function (submissionState, submissionId) {
             var total = 0;
 
             for (var key in $scope.submissionStatuses) {
                 if ($scope.submissionStatuses[key].submissionState === submissionState) {
                     if ($scope.submissionStatuses[key].isDefault === true) {
-                        total++;
+                        if (!angular.isDefined(submissionId) || $scope.submissionStatuses[key].id !== submissionId) {
+                            total++;
+                        }
                     }
                 }
             }
@@ -143,8 +145,17 @@ vireo.controller("SubmissionStatusController", function ($controller, $scope, $q
             return total;
         };
 
-        $scope.invalidDefaultForState = function(isDefault, submissionState) {
-            return isDefault === false && $scope.totalDefaultsForSubmissionState(submissionState) !== 1;
+        $scope.invalidDefaultForState = function(isDefault, submissionState, submissionId) {
+            if (isDefault === true || isDefault === "true") {
+                return false;
+            }
+
+            var id = submissionId;
+            if (angular.isDefined(submissionId)) {
+                id = parseInt(submissionId);
+            }
+
+            return $scope.totalDefaultsForSubmissionState(submissionState, id) !== 1;
         };
 
         $scope.submissionStatusRepo.listen([ApiResponseActions.CREATE, ApiResponseActions.UPDATE, ApiResponseActions.DELETE], function (data) {

--- a/src/main/webapp/app/filters/withoutId.js
+++ b/src/main/webapp/app/filters/withoutId.js
@@ -1,0 +1,11 @@
+vireo.filter('withouutId', function() {
+    return function(initialValues, withoutId) {
+        var newValues = [];
+        angular.forEach(initialValues, function(value) {
+            if (value.id !== withoutId) {
+                newValues.push(value);
+            }
+        });
+        return newValues;
+    };
+});

--- a/src/main/webapp/app/views/modals/settings/submissionStatusConfirmModal.html
+++ b/src/main/webapp/app/views/modals/settings/submissionStatusConfirmModal.html
@@ -10,11 +10,11 @@
     <validationmessage results="submissionStatusRepo.getValidationResults()"></validationmessage>
 
     <div class="modal-body">
-        <span ng-show="!modalData.isDefault">
+        <span ng-show="!canRemoveSubmissionStatus(modalData.isDefault)">
             <h4><b>Click confirm to remove the Submission Status:</b></h4>
             <span class="glyphicon glyphicon glyphicon-user"></span>
         </span>
-        <span ng-show="modalData.isDefault">
+        <span ng-show="canRemoveSubmissionStatus(modalData.isDefault)">
             <h4><b>Cannot delete default Submission Status:</b></h4>
             <span class="glyphicon glyphicon glyphicon-globe"></span>
         </span>
@@ -23,6 +23,6 @@
 
     <div class="modal-footer">
         <button type="button" class="btn btn-default" ng-click="resetSubmissionStatus()">Cancel</button>
-        <button id="submissionStatus-confirm" type="submit" class="btn btn-primary" ng-disabled="modalData.isDefault">Confirm</button>
+        <button id="submissionStatus-confirm" type="submit" class="btn btn-primary" ng-disabled="canRemoveSubmissionStatus(modalData.isDefault)">Confirm</button>
     </div>
 </form>

--- a/src/main/webapp/app/views/modals/settings/submissionStatusEditModal.html
+++ b/src/main/webapp/app/views/modals/settings/submissionStatusEditModal.html
@@ -32,6 +32,10 @@
         <toggleButton id="edit-is-publishable" label="Publishable:" scope-value="modalData.isPublishable" toggle-options="{{toggleOptions}}"></toggleButton>
         <toggleButton id="edit-clear-approval" label="Clear Approval:" scope-value="modalData.clearApproval" toggle-options="{{toggleOptions}}"></toggleButton>
 
+        <div ng-if="modalData.submissionState !== 'NONE' && invalidDefaultForState(modalData.isDefault, modalData.submissionState, modalData.id)">
+            <b>A default must be specified for the selected state.</b>
+        </div>
+
         <validatedselect
             id="edit-submission-state"
             options="submissionStates"
@@ -49,10 +53,6 @@
               <option ng-repeat="option in submissionStatuses" ng-value="option.id">{{option.name}}</option>
             </select>
         </div>
-
-        <div ng-if="modalData.submissionState !== 'NONE' && invalidDefaultForState(modalData.isDefault, modalData.submissionState)">
-            <b>A default must be specified for the selected state.</b>
-        </div>
     </div>
 
     <div class="modal-footer">
@@ -64,6 +64,6 @@
             id="edit-submissionStatus-save"
             type="submit"
             class="btn btn-primary"
-            ng-disabled="forms.update.$invalid || invalidDefaultForState(modalData.isDefault, modalData.submissionState)">Update</button>
+            ng-disabled="forms.update.$invalid || invalidDefaultForState(modalData.isDefault, modalData.submissionState, modalData.id)">Update</button>
     </div>
 </form>

--- a/src/main/webapp/app/views/modals/settings/submissionStatusEditModal.html
+++ b/src/main/webapp/app/views/modals/settings/submissionStatusEditModal.html
@@ -50,7 +50,7 @@
         <div class="form-group">
             <label for="edit-transition-submission-statuses">Transition Submission Statuses</label>
             <select class="form-control" name="edit-transition-submission-statuses" ng-model="modalData.transitionSubmissionStatuses" multiple>
-              <option ng-repeat="option in submissionStatuses" ng-value="option.id">{{option.name}}</option>
+              <option ng-repeat="option in submissionStatuses | withouutId : modalData.id" ng-value="option.id">{{option.name}}</option>
             </select>
         </div>
     </div>

--- a/src/main/webapp/app/views/modals/settings/submissionStatusNewModal.html
+++ b/src/main/webapp/app/views/modals/settings/submissionStatusNewModal.html
@@ -32,6 +32,11 @@
         <toggleButton id="new-is-publishable" label="Publishable:" scope-value="modalData.isPublishable" toggle-options="{{toggleOptions}}"></toggleButton>
         <toggleButton id="new-clear-approval" label="Clear Approval:" scope-value="modalData.clearApproval" toggle-options="{{toggleOptions}}"></toggleButton>
 
+
+        <div ng-if="modalData.submissionState !== 'NONE' && invalidDefaultForState(modalData.isDefault, modalData.submissionState)">
+            <b>A default must be specified for the selected state.</b>
+        </div>
+
         <validatedselect
             id="new-submission-state"
             options="submissionStates"
@@ -60,6 +65,6 @@
             id="new-submissionStatus-save"
             type="submit"
             class="btn btn-primary"
-            ng-disabled="forms.create.$invalid">Create</button>
+            ng-disabled="forms.create.$invalid || invalidDefaultForState(modalData.isDefault, modalData.submissionState)">Create</button>
     </div>
 </form>

--- a/src/main/webapp/tests/unit/controllers/settings/submissionStatusControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/submissionStatusControllerTest.js
@@ -57,6 +57,10 @@ describe("controller: SubmissionStatusController", function () {
     });
 
     describe("Are the scope methods defined", function () {
+        it("canRemoveSubmissionStatus should be defined", function () {
+            expect(scope.canRemoveSubmissionStatus).toBeDefined();
+            expect(typeof scope.canRemoveSubmissionStatus).toEqual("function");
+        });
         it("createSubmissionStatus should be defined", function () {
             expect(scope.createSubmissionStatus).toBeDefined();
             expect(typeof scope.createSubmissionStatus).toEqual("function");
@@ -111,6 +115,13 @@ describe("controller: SubmissionStatusController", function () {
     });
 
     describe("Do the scope methods work as expected", function () {
+        it("canRemoveSubmissionStatus should return a boolean", function () {
+            expect(scope.canRemoveSubmissionStatus()).toBe(false);
+            expect(scope.canRemoveSubmissionStatus(false)).toBe(false);
+            expect(scope.canRemoveSubmissionStatus("false")).toBe(false);
+            expect(scope.canRemoveSubmissionStatus(true)).toBe(true);
+            expect(scope.canRemoveSubmissionStatus("true")).toBe(true);
+        });
         it("createSubmissionStatus should create a submission status", function () {
             scope.modalData = new mockSubmissionStatus(q);
 

--- a/src/main/webapp/tests/unit/controllers/settings/submissionStatusControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/submissionStatusControllerTest.js
@@ -148,6 +148,33 @@ describe("controller: SubmissionStatusController", function () {
 
             response = scope.invalidDefaultForState(false, "IN_PROGRESS");
             expect(response).toEqual(false);
+
+            scope.submissionStatuses = [];
+
+            response = scope.invalidDefaultForState(true, "IN_PROGRESS", 1);
+            expect(response).toEqual(false);
+
+            response = scope.invalidDefaultForState(false, "IN_PROGRESS", 1);
+            expect(response).toEqual(true);
+
+            scope.submissionStatuses = [
+                new mockSubmissionStatus(q),
+                new mockSubmissionStatus(q)
+            ];
+
+            response = scope.invalidDefaultForState(true, "IN_PROGRESS", 1);
+            expect(response).toEqual(false);
+
+            response = scope.invalidDefaultForState(false, "IN_PROGRESS", 1);
+            expect(response).toEqual(true);
+
+            scope.submissionStatuses[1].mock(dataSubmissionStatus2);
+
+            response = scope.invalidDefaultForState(true, "IN_PROGRESS", 1);
+            expect(response).toEqual(false);
+
+            response = scope.invalidDefaultForState(false, "IN_PROGRESS", 1);
+            expect(response).toEqual(true);
         });
         it("launchEditModal should open a modal", function () {
             scope.modalData = null;


### PR DESCRIPTION
Implement and use custom exception handling instead of returning `ApiResponse.INVALID`.
This is more robust, allows for cleaner code, and better reports problems via existing infrastructure.

Also make sure to actually handle the possible errors.

Improve handling of potential problems with form data formats and potential browser compatibility issues.

Improve and fix related tests.