### PR TITLE
Improve CLI generation, fixing embargoes to be actual embargoes and several others.

### DIFF
--- a/src/main/java/org/tdl/vireo/service/CliService.java
+++ b/src/main/java/org/tdl/vireo/service/CliService.java
@@ -144,8 +144,6 @@ public class CliService {
                 programsVW.add(vw);
             } else if (vw.getControlledVocabulary().getName().equalsIgnoreCase("schools")) {
                 schoolsVW.add(vw);
-            } else if (vw.getControlledVocabulary().getName().equalsIgnoreCase("schools")) {
-                schoolsVW.add(vw);
             }
         });
 


### PR DESCRIPTION
The embargoes are now generated from the actual list of embargoes. If there are no embargoes then it falls back to a randomly generated string.

Handle other similar cases that are easy to resolve at the same time. This makes the generated data more accurate and easier to test. Especially when using them for filtering.

Switch to `localhost.localdomain` for example address to avoid any potential accidents if e-mails are sent (etc..).