### PR TITLE
Issue 54: Add custom filter for embargo type by list.

### DIFF
--- a/src/main/resources/submission_list_columns/SYSTEM_Default_Submission_List_Columns.json
+++ b/src/main/resources/submission_list_columns/SYSTEM_Default_Submission_List_Columns.json
@@ -197,5 +197,17 @@
     "inputType": {
       "name": "INPUT_TEXT"
     }
+  },
+  {
+    "title": "Embargo Type",
+    "sort": "NONE",
+    "valuePath": [
+      "embargoTypes",
+      "name"
+    ],
+    "status": null,
+    "inputType": {
+      "name": "INPUT_TEXT"
+    }
   }
 ]

--- a/src/main/webapp/app/filters/uniqueEmbargoType.js
+++ b/src/main/webapp/app/filters/uniqueEmbargoType.js
@@ -1,0 +1,16 @@
+vireo.filter('uniqueEmbargoType', function() {
+  return function(initialValues, isActive) {
+    var matched = [];
+    var newValues = [];
+    if (typeof initialValues === "object") {
+      angular.forEach(initialValues, function(embargo) {
+        if (matched.includes(embargo.name)) return;
+        if (embargo.isActive !== isActive) return;
+
+        matched.push(embargo.name);
+        newValues.push(embargo);
+      });
+    }
+    return newValues;
+  };
+});

--- a/src/main/webapp/app/resources/styles/sass/app.scss
+++ b/src/main/webapp/app/resources/styles/sass/app.scss
@@ -524,6 +524,7 @@ sidebox ul.sidebox-list input {
   padding: 15px;
 }
 
+.sidebox-body ul.sidebox-list.embargotype-list,
 .sidebox-body ul.sidebox-list.status-list {
   padding: 0px;
 }
@@ -1560,6 +1561,7 @@ input[type=color]:focus {
   text-decoration: underline;
 }
 
+.further-filter-by .embargotype-category,
 .further-filter-by .status-category {
   background: #CCCCCC;
   display: inline-block;
@@ -1572,6 +1574,7 @@ input[type=color]:focus {
 .further-filter-by .document-type-list,
 .further-filter-by .inactive-filters-sub-list,
 .further-filter-by .organization-by-category-sub-list,
+.further-filter-by .embargotype-list,
 .further-filter-by .status-list {
   max-height: 0;
   overflow: hidden;
@@ -1587,6 +1590,7 @@ input[type=color]:focus {
 .further-filter-by .document-type-list.expanded,
 .further-filter-by .inactive-filters-sub-list.expanded,
 .further-filter-by .organization-by-category-sub-list.expanded,
+.further-filter-by .embargotype-list.expanded,
 .further-filter-by .status-list.expanded {
   max-height: 1000px;
   -webkit-transition: max-height 0.5s ease-in;

--- a/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterByEmbargoType.html
+++ b/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterByEmbargoType.html
@@ -1,17 +1,17 @@
-<form ng-init="box.embargosLimit=box.defaultLimit;" name="{{'box.'+(column.title.split(' ').join(''))+'Form'}}">
-	<ul class="sidebox-list">
-		<li class="filter" ng-repeat="et in box.embargos | filter:{isActive: true} | limitTo:box.embargosLimit" ng-click="box[column.title.split(' ').join('')]=et.name;box.addExactMatchFilter(column);"><span ng-if="et.systemRequired" class="glyphicon glyphicon-globe"></span><span ng-if="!et.systemRequired" class="glyphicon glyphicon-user"></span> {{et.name}}</li>
-		<li class="more-less" ng-click="box.embargosLimit=box.embargos.length" ng-if="box.embargosLimit<=box.defaultLimit && box.embargos.length>box.defaultLimit">more...</li>
-		<li class="more-less" ng-click="box.embargosLimit=box.defaultLimit" ng-if="box.embargosLimit>box.defaultLimit">less...</li>
-	</ul>
-
-	<ul class="sidebox-list">
-		<li class="more-less" ng-click="box.inactiveFilterExpand=box.inactiveFilterExpand?!box.inactiveFilterExpand:true"><span ng-if="!box.inactiveFilterExpand">+</span><span ng-if="box.inactiveFilterExpand">-</span> Inactive</li>
-		<li ng-class="{'expanded': box.inactiveFilterExpand}" class="inactive-filters-sub-list">
-			<ul>
-				<li class="embargo-filter filter" ng-repeat="et in box.embargos | filter:{isActive: false}" ng-click="box[column.title.split(' ').join('')]=et.name;box.addExactMatchFilter(column);"><span ng-if="et.systemRequired" class="glyphicon glyphicon-globe"></span><span ng-if="!et.systemRequired" class="glyphicon glyphicon-user"></span> {{et.name}}</li>
-			</ul>
-		</li>
-	</ul>
-
+<form name="{{'box.'+(column.title.split(' ').join(''))+'Form'}}">
+  <ul class="sidebox-list">
+    <li class="filter" ng-click="box[column.title.split(' ').join('')]=ss.name;box.addExactMatchFilter(column);" ng-repeat="et in box.embargos | uniqueEmbargoType">{{et.name}}</li>
+    <li ng-click="activeExpanded = activeExpanded ? !activeExpanded : true" class="embargotype-category">+ Active</li>
+    <li>
+      <ul class="sidebox-list embargotype-list" ng-class="{'expanded': activeExpanded}">
+        <li class="filter" ng-click="box[column.title.split(' ').join('')]=et.name;box.addExactMatchFilter(column);" ng-repeat="et in box.embargos | uniqueEmbargoType:true"><span ng-if="et.systemRequired" class="glyphicon glyphicon-globe"></span><span ng-if="!et.systemRequired" class="glyphicon glyphicon-user"></span> {{et.name}}</li>
+      </ul>
+    </li>
+    <li ng-click="inactiveExpanded = inactiveExpanded ? !inactiveExpanded : true" class="embargotype-category">+ Inactive</li>
+    <li>
+      <ul class="sidebox-list embargotype-list" ng-class="{'expanded': inactiveExpanded}">
+        <li class="filter" ng-click="box[column.title.split(' ').join('')]=et.name;box.addExactMatchFilter(column);" ng-repeat="et in box.embargos | uniqueEmbargoType:false"><span ng-if="et.systemRequired" class="glyphicon glyphicon-globe"></span><span ng-if="!et.systemRequired" class="glyphicon glyphicon-user"></span> {{et.name}}</li>
+      </ul>
+    </li>
+  </ul>
 </form>

--- a/src/main/webapp/tests/unit/filters/uniqueEmbargoTypeTest.js
+++ b/src/main/webapp/tests/unit/filters/uniqueEmbargoTypeTest.js
@@ -1,0 +1,101 @@
+describe("filter: uniqueEmbargoType", function () {
+  var $scope, MockedUser, filter;
+
+  var initializeVariables = function () {
+    inject(function (_$q_) {
+      $q = _$q_;
+
+      MockedUser = new mockUser($q);
+    });
+  };
+
+  var initializeFilter = function (settings) {
+    inject(function (_$filter_, _$rootScope_) {
+      $scope = _$rootScope_.$new();
+
+      filter = _$filter_("uniqueEmbargoType");
+    });
+  };
+
+  beforeEach(function () {
+    module("core");
+    module("vireo");
+    module("mock.user", function ($provide) {
+      var User = function () {
+        return MockedUser;
+      };
+      $provide.value("User", User);
+    });
+    module("mock.userService");
+
+    installPromiseMatchers();
+    initializeVariables();
+    initializeFilter();
+  });
+
+  afterEach(function () {
+    $scope.$destroy();
+  });
+
+  describe("Is the filter", function () {
+    it("defined", function () {
+      expect(filter).toBeDefined();
+    });
+  });
+
+  describe("Does the filter", function () {
+    it("return empty array on empty input", function () {
+      var result;
+
+      result = filter("", false);
+
+      expect(result).toEqual([]);
+
+      result = filter("", true);
+
+      expect(result).toEqual([]);
+
+      result = filter(null, false);
+
+      expect(result).toEqual([]);
+
+      result = filter(null, true);
+
+      expect(result).toEqual([]);
+
+      result = filter([], false);
+
+      expect(result).toEqual([]);
+
+      result = filter([], true);
+
+      expect(result).toEqual([]);
+
+      result = filter({}, false);
+
+      expect(result).toEqual([]);
+
+      result = filter({}, true);
+
+      expect(result).toEqual([]);
+    });
+
+    it("return array with duplicate removed for active", function () {
+      var result;
+      var duplicated = [ dataEmbargo1, dataEmbargo2, dataEmbargo1, dataEmbargo3 ];
+
+      result = filter(duplicated, true);
+
+      expect(result.length).toBe(2);
+    });
+
+    it("return array with duplicate removed for inactive", function () {
+      var result;
+      var duplicated = [ dataEmbargo3, dataEmbargo2, dataEmbargo3, dataEmbargo1 ];
+
+      result = filter(duplicated, false);
+
+      expect(result.length).toBe(1);
+    });
+  });
+});

--- a/src/test/java/org/tdl/vireo/service/SystemDataLoaderTest.java
+++ b/src/test/java/org/tdl/vireo/service/SystemDataLoaderTest.java
@@ -492,7 +492,7 @@ public class SystemDataLoaderTest {
     }
 
     private void assertSubmissionListColumn(boolean isReload) {
-        assertEquals(59, submissionListColumnRepo.count(),
+        assertEquals(60, submissionListColumnRepo.count(),
             isReload
                 ? "Incorrect number of submissionListColumn found after reload"
                 : "Incorrect number of submissionListColumn found");


### PR DESCRIPTION
resolves #54

There is existing (dead) code for this already.
Re-vitalize the dead code, clean it up, and get it working.

The `embargoTypes.name` SQL in the back-end operates differently in that it is not involved in part of a column name and is exclusively for filtering. This changes the nature of the query and I opted to go with sub-queries for selecting the IDs because I can design it this way and avoid `LEFT JOIN` (or `INNER JOIN`). This has not seen extensive performance testing but this new SQL query conditions should be run through some performance testing.

I went with `Embargo Type` for the new custom filter because the existing code used that name.

A custom filter `uniqueEmbargoType` is created because the `unique`/`uniq` angularjs is not available. Using `unique` or `uniq` yields an error like this:
```
Unknown provider: uniqueFilterProvider <- uniqueFilter
```

Using the custom filter (`uniqueEmbargoType`) avoids having to pass the additional ` | filter:{isActive: true}` and similar. This can be done and is done within the same filter.

This adds a unit test for the filter (AngularJS context of filter) for the Embargo Type filter (Vireo table list context of filter).

The addition of the `Embargo Type` causes a test in the `SystemDataLoaderTest` class to fail due to a hard-coded value representing all of the default filters. This has been updated to include the new filter in the total.

The UI has an existing filter view, but it was slightly tweak that filter view to address problems in the user experience. I opted to make its design more closely match that of the Status filter (which goes in line with the issue request using Status filter as an example).