### PR TITLE
Issue 55: Add custom filter for submission type by list.

### DIFF
--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -129,13 +129,15 @@ public class Cli implements CommandLineRunner {
                             Random random = new Random();
                             int idOffset = cliService.countUsers();
                             User helpfulHarry = null;
+                            boolean hasSubmissionTypes = false;
 
                             if (expansive) {
                                 helpfulHarry = cliService.createHelpfulHarry(idOffset++, CliService.EMAIL_DATE);
+                                hasSubmissionTypes = cliService.hasSubmissionTypes();
                             }
 
                             for (int i = itemsGenerated; i < num1 + itemsGenerated; i++) {
-                                cliService.operateGenerate(expansive, num2, random, idOffset, helpfulHarry, i);
+                                cliService.operateGenerate(expansive, num2, random, idOffset, helpfulHarry, hasSubmissionTypes, i);
                                 System.out.print("\r" + (i - itemsGenerated) + " of " + num1 + " generated...");
                             }
 

--- a/src/main/java/org/tdl/vireo/controller/FieldValueController.java
+++ b/src/main/java/org/tdl/vireo/controller/FieldValueController.java
@@ -1,0 +1,44 @@
+package org.tdl.vireo.controller;
+
+import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
+
+import edu.tamu.weaver.response.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.tdl.vireo.model.FieldPredicate;
+import org.tdl.vireo.model.repo.FieldPredicateRepo;
+import org.tdl.vireo.model.repo.FieldValueRepo;
+
+/**
+ * Controller in which to manage controlled vocabulary.
+ *
+ */
+@RestController
+@RequestMapping("/settings/field-values")
+public class FieldValueController {
+
+    @Autowired
+    private FieldPredicateRepo fieldPredicateRepo;
+
+    @Autowired
+    private FieldValueRepo fieldValueRepo;
+
+    /**
+     * Endpoint to request a field predicate by value.
+     *
+     * @param value The Field Predicate value (not the Field Value).
+     *
+     * @return ApiResponse with all matching field values.
+     */
+    @GetMapping("/predicate/{value}")
+    @PreAuthorize("hasRole('STUDENT')")
+    public ApiResponse getFieldValuesByPredicateValue(@PathVariable String value) {
+        final FieldPredicate fieldPredicate = fieldPredicateRepo.findByValue(value);
+        return new ApiResponse(SUCCESS, fieldValueRepo.findAllByFieldPredicate(fieldPredicate));
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/repo/FieldValueRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/FieldValueRepo.java
@@ -1,10 +1,14 @@
 package org.tdl.vireo.model.repo;
 
+import org.tdl.vireo.model.FieldPredicate;
 import org.tdl.vireo.model.FieldValue;
 import org.tdl.vireo.model.repo.custom.FieldValueRepoCustom;
 
 import edu.tamu.weaver.data.model.repo.WeaverRepo;
+import java.util.List;
 
 public interface FieldValueRepo extends WeaverRepo<FieldValue>, FieldValueRepoCustom {
+
+    public List<FieldValue> findAllByFieldPredicate(FieldPredicate fieldPredicate);
 
 }

--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -775,7 +775,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         sqlBuilder = new StringBuilder();
                         sqlBuilder.append("s.id IN (SELECT submission_id FROM submission_field_values WHERE field_values_id IN (select id FROM field_value WHERE field_predicate_id IN (SELECT id FROM field_predicate WHERE value = 'submission_type') and (");
 
-                        // Note that the OR query is used inside the column, represented by both default_embargos and proquest_embargos.
+                        // Note that the OR query is used inside the column, represented by submission_type.
                         boolean hasNone = false;
                         for (String filterString : submissionListColumn.getFilters()) {
                             if (filterString != null) {

--- a/src/main/java/org/tdl/vireo/service/CliService.java
+++ b/src/main/java/org/tdl/vireo/service/CliService.java
@@ -30,6 +30,7 @@ import org.tdl.vireo.model.repo.ActionLogRepo;
 import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
 import org.tdl.vireo.model.repo.DegreeRepo;
 import org.tdl.vireo.model.repo.EmbargoRepo;
+import org.tdl.vireo.model.repo.FieldPredicateRepo;
 import org.tdl.vireo.model.repo.FieldValueRepo;
 import org.tdl.vireo.model.repo.LanguageRepo;
 import org.tdl.vireo.model.repo.OrganizationRepo;
@@ -84,6 +85,9 @@ public class CliService {
     private DegreeRepo degreeRepo;
 
     @Autowired
+    private FieldPredicateRepo fieldPredicateRepo;
+
+    @Autowired
     private BCryptPasswordEncoder passwordEncoder;
 
     public void operateAccounts(boolean expansive, int generateTotal) {
@@ -110,7 +114,12 @@ public class CliService {
         }
     }
 
-    public void operateGenerate(boolean expansive, int maxActionLogs, Random random, int idOffset, User helpfulHarry, int i) throws OrganizationDoesNotAcceptSubmissionsException {
+    public boolean hasSubmissionTypes() {
+        FieldPredicate submissionTypeFP = fieldPredicateRepo.findByValue("submission_type");
+        return fieldValueRepo.findAllByFieldPredicate(submissionTypeFP).size() > 0;
+    }
+
+    public void operateGenerate(boolean expansive, int maxActionLogs, Random random, int idOffset, User helpfulHarry, boolean hasSubmissionTypes, int i) throws OrganizationDoesNotAcceptSubmissionsException {
         Calendar now = Calendar.getInstance();
         User submitter = userRepo.create("bob" + EMAIL_DATE.format(now.getTime()) + (idOffset + i + 1) + "@boring.bob", "bob", "boring " + (idOffset + i + 1), Role.ROLE_STUDENT);
         Credentials credentials = new Credentials();
@@ -129,6 +138,7 @@ public class CliService {
         final List<VocabularyWord> departmentsVW = new ArrayList<>();
         final List<VocabularyWord> schoolsVW = new ArrayList<>();
         final List<VocabularyWord> majorsVW = new ArrayList<>();
+        final List<FieldValue> submissionTypesVW = new ArrayList<>();
         Organization org = orgs.get(getRandomNumber(organizationRepo.findAll().size()));
         SubmissionStatus state = statuses.get(0);
         setAcceptSubmissions(org);
@@ -146,6 +156,13 @@ public class CliService {
                 schoolsVW.add(vw);
             }
         });
+
+        if (hasSubmissionTypes) {
+            FieldPredicate submissionTypeFP = fieldPredicateRepo.findByValue("submission_type");
+            fieldValueRepo.findAllByFieldPredicate(submissionTypeFP).forEach((FieldValue fv) -> {
+                submissionTypesVW.add(fv);
+            });
+        }
 
         // Status is chosen completely randomly for every option available when expansive is enabled.
         if (expansive) {
@@ -292,6 +309,17 @@ public class CliService {
                         val.setValue("test " + pred.getValue() + " " + i);
                         val.setContacts(Arrays.asList(new String[] { "test" + pred.getValue() + i + AT_ADDRESS }));
                         sub.addFieldValue(val);
+                    } else if (pred.getValue().equalsIgnoreCase("submission_type")) {
+                        FieldValue fv = null;
+                        if (submissionTypesVW.size() > 0) {
+                            fv = submissionTypesVW.get(getRandomNumber(submissionTypesVW.size()));
+                        }
+
+                        if (fv == null) {
+                            val.setValue("test " + pred.getValue() + " " + getRandomNumber(10));
+                        } else {
+                            val.setValue(fv.getValue());
+                        }
                     } else {
                         val.setValue("test " + pred.getValue() + " " + i);
                     }

--- a/src/main/resources/submission_list_columns/SYSTEM_Default_Submission_List_Columns.json
+++ b/src/main/resources/submission_list_columns/SYSTEM_Default_Submission_List_Columns.json
@@ -209,5 +209,17 @@
     "inputType": {
       "name": "INPUT_TEXT"
     }
+  },
+  {
+    "title": "Submission Type (List)",
+    "sort": "NONE",
+    "valuePath": [
+      "submissionTypes",
+      "name"
+    ],
+    "status": null,
+    "inputType": {
+      "name": "INPUT_TEXT"
+    }
   }
 ]

--- a/src/main/webapp/app/controllers/settings/organizationManagementController.js
+++ b/src/main/webapp/app/controllers/settings/organizationManagementController.js
@@ -98,13 +98,17 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
     };
 
     $scope.reorderWorkflowStepUp = function (workflowStepID) {
-        $scope.getSelectedOrganization().$dirty = true;
+        if (!!$scope.getSelectedOrganization()) {
+          $scope.getSelectedOrganization().$dirty = true;
+        }
         AccordionService.closeAll();
         return OrganizationRepo.reorderWorkflowSteps("up", workflowStepID);
     };
 
     $scope.reorderWorkflowStepDown = function (workflowStepID) {
-        $scope.getSelectedOrganization().$dirty = true;
+        if (!!$scope.getSelectedOrganization()) {
+          $scope.getSelectedOrganization().$dirty = true;
+        }
         AccordionService.closeAll();
         return OrganizationRepo.reorderWorkflowSteps("down", workflowStepID);
     };

--- a/src/main/webapp/app/filters/uniqueSubmissionTypeList.js
+++ b/src/main/webapp/app/filters/uniqueSubmissionTypeList.js
@@ -1,0 +1,15 @@
+vireo.filter('uniqueSubmissionTypeList', function() {
+  return function(initialValues, isActive) {
+    var matched = [];
+    var newValues = [];
+    if (typeof initialValues === 'object') {
+      angular.forEach(initialValues, function(fv) {
+        if (matched.includes(fv.value)) return;
+
+        matched.push(fv.value);
+        newValues.push(fv);
+      });
+    }
+    return newValues;
+  };
+});

--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -340,6 +340,7 @@ var submissionModel = function ($filter, $q, ActionLog, FieldValue, FileService,
                     resolve();
                 });
             }
+
             angular.extend(this.getMapping().validateFieldValue, {
                 method: submission.id + "/validate-field-value/" + fieldProfile.id,
                 data: fieldValue

--- a/src/main/webapp/app/repo/fieldValueRepo.js
+++ b/src/main/webapp/app/repo/fieldValueRepo.js
@@ -1,0 +1,31 @@
+vireo.repo("FieldValueRepo", function FieldValueRepo(FieldValue, WsApi) {
+
+  var fieldValueRepo = this;
+
+  fieldValueRepo.findByPredicateValue = function(value) {
+      var fieldValues = [];
+
+      // FieldValue exists on the API Mapping but is under the Submission controller, which is not correct and so manually define the entire mapping inline here.
+      var mapping = {
+        'endpoint': '/private/queue',
+        'controller': 'settings/field-values',
+        'method': 'predicate/' + value
+      };
+
+      WsApi.fetch(mapping).then(function(res) {
+          if (!!res && !!res.body) {
+            var resObj = angular.fromJson(res.body);
+            if (resObj.meta.status === 'SUCCESS') {
+                var values = resObj.payload['ArrayList<FieldValue>'];
+                for (var i in values) {
+                    fieldValues.push(new FieldValue(values[i]));
+                }
+            }
+          }
+      });
+
+      return fieldValues;
+  };
+
+  return fieldValueRepo;
+});

--- a/src/main/webapp/app/resources/styles/sass/app.scss
+++ b/src/main/webapp/app/resources/styles/sass/app.scss
@@ -525,6 +525,7 @@ sidebox ul.sidebox-list input {
 }
 
 .sidebox-body ul.sidebox-list.embargotype-list,
+.sidebox-body ul.sidebox-list.submissiontype-list,
 .sidebox-body ul.sidebox-list.status-list {
   padding: 0px;
 }
@@ -1562,6 +1563,7 @@ input[type=color]:focus {
 }
 
 .further-filter-by .embargotype-category,
+.further-filter-by .submissiontype-category,
 .further-filter-by .status-category {
   background: #CCCCCC;
   display: inline-block;
@@ -1575,6 +1577,7 @@ input[type=color]:focus {
 .further-filter-by .inactive-filters-sub-list,
 .further-filter-by .organization-by-category-sub-list,
 .further-filter-by .embargotype-list,
+.further-filter-by .submissiontype-list,
 .further-filter-by .status-list {
   max-height: 0;
   overflow: hidden;
@@ -1591,6 +1594,7 @@ input[type=color]:focus {
 .further-filter-by .inactive-filters-sub-list.expanded,
 .further-filter-by .organization-by-category-sub-list.expanded,
 .further-filter-by .embargotype-list.expanded,
+.further-filter-by .submissiontype-list.expanded,
 .further-filter-by .status-list.expanded {
   max-height: 1000px;
   -webkit-transition: max-height 0.5s ease-in;

--- a/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterBy.html
+++ b/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterBy.html
@@ -31,6 +31,10 @@
             <div ng-include="'views/sideboxes/furtherFilterBy/furtherFilterBySubmissionType.html'"></div>
         </div>
 
+        <div ng-switch-when="Submission Type (List)">
+            <div ng-include="'views/sideboxes/furtherFilterBy/furtherFilterBySubmissionTypeList.html'"></div>
+        </div>
+
         <div ng-switch-when="Proquest Publication">
             <div ng-include="'views/sideboxes/furtherFilterBy/furtherFilterByUmiPublication.html'"></div>
         </div>

--- a/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterByEmbargoType.html
+++ b/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterByEmbargoType.html
@@ -1,6 +1,6 @@
 <form name="{{'box.'+(column.title.split(' ').join(''))+'Form'}}">
   <ul class="sidebox-list">
-    <li class="filter" ng-click="box[column.title.split(' ').join('')]=ss.name;box.addExactMatchFilter(column);" ng-repeat="et in box.embargos | uniqueEmbargoType">{{et.name}}</li>
+    <li class="filter" ng-click="box[column.title.split(' ').join('')]=et.name;box.addExactMatchFilter(column);" ng-repeat="et in box.embargos | uniqueEmbargoType">{{et.name}}</li>
     <li ng-click="activeExpanded = activeExpanded ? !activeExpanded : true" class="embargotype-category">+ Active</li>
     <li>
       <ul class="sidebox-list embargotype-list" ng-class="{'expanded': activeExpanded}">

--- a/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterBySubmissionTypeList.html
+++ b/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterBySubmissionTypeList.html
@@ -1,0 +1,5 @@
+<form name="{{'box.SubmissionTypeListForm'}}">
+  <ul class="sidebox-list">
+    <li class="filter" ng-click="box.SubmissionTypeList=st.value;box.addExactMatchFilter(column);" ng-repeat="st in box.submissionTypeList | uniqueSubmissionTypeList">{{st.value}}</li>
+  </ul>
+</form>

--- a/src/main/webapp/tests/mocks/models/mockFieldValue.js
+++ b/src/main/webapp/tests/mocks/models/mockFieldValue.js
@@ -8,7 +8,7 @@ var dataFieldValue1 = {
         value: "_doctype_primary"
     },
     identifier: "",
-    value: ""
+    value: "dataFieldValue1"
 };
 
 var dataFieldValue2 = {
@@ -24,7 +24,7 @@ var dataFieldValue2 = {
         name: "test"
     },
     identifier: "",
-    value: ""
+    value: "dataFieldValue2"
 };
 
 var dataFieldValue3 = {
@@ -33,7 +33,7 @@ var dataFieldValue3 = {
     definition: "",
     fieldPredicate: null,
     identifier: "",
-    value: ""
+    value: "dataFieldValue3"
 };
 
 var dataFieldValue4 = {
@@ -46,7 +46,7 @@ var dataFieldValue4 = {
         value: "text/plain"
     },
     identifier: "",
-    value: ""
+    value: "dataFieldValue4"
 };
 
 var dataFieldValue5 = {
@@ -59,7 +59,7 @@ var dataFieldValue5 = {
         value: "application/pdf"
     },
     identifier: "",
-    value: ""
+    value: "dataFieldValue5"
 };
 
 var dataFieldValue6 = {
@@ -75,7 +75,7 @@ var dataFieldValue6 = {
         name: "test.csv"
     },
     identifier: "",
-    value: ""
+    value: "dataFieldValue6"
 };
 
 

--- a/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
@@ -568,6 +568,12 @@ describe("controller: SubmissionListController", function () {
 
             expect(location.path).toHaveBeenCalled();
         });
+        it(" should simplifyTitle fix the string", function () {
+            var result = scope.simplifyTitle("a(b)c d");
+            scope.$digest();
+
+            expect(result).toEqual("abcd");
+        });
     });
 
     describe("Do the scope.furtherFilterBy methods work as expected", function () {

--- a/src/main/webapp/tests/unit/filters/uniqueSubmissionTypeListTest.js
+++ b/src/main/webapp/tests/unit/filters/uniqueSubmissionTypeListTest.js
@@ -1,0 +1,76 @@
+describe("filter: uniqueSubmissionTypeList", function () {
+  var $scope, MockedUser, filter;
+
+  var initializeVariables = function () {
+    inject(function (_$q_) {
+      $q = _$q_;
+
+      MockedUser = new mockUser($q);
+    });
+  };
+
+  var initializeFilter = function (settings) {
+    inject(function (_$filter_, _$rootScope_) {
+      $scope = _$rootScope_.$new();
+
+      filter = _$filter_("uniqueSubmissionTypeList");
+    });
+  };
+
+  beforeEach(function () {
+    module("core");
+    module("vireo");
+    module("mock.user", function ($provide) {
+      var User = function () {
+        return MockedUser;
+      };
+      $provide.value("User", User);
+    });
+    module("mock.userService");
+
+    installPromiseMatchers();
+    initializeVariables();
+    initializeFilter();
+  });
+
+  afterEach(function () {
+    $scope.$destroy();
+  });
+
+  describe("Is the filter", function () {
+    it("defined", function () {
+      expect(filter).toBeDefined();
+    });
+  });
+
+  describe("Does the filter", function () {
+    it("return empty array on empty input", function () {
+      var result;
+
+      result = filter("");
+
+      expect(result).toEqual([]);
+
+      result = filter(null);
+
+      expect(result).toEqual([]);
+
+      result = filter([]);
+
+      expect(result).toEqual([]);
+
+      result = filter({});
+
+      expect(result).toEqual([]);
+    });
+
+    it("return array with duplicate removed", function () {
+      var result;
+      var duplicated = [ dataFieldValue1, dataFieldValue2, dataFieldValue1 ];
+
+      result = filter(duplicated, true);
+
+      expect(result.length).toBe(2);
+    });
+  });
+});

--- a/src/main/webapp/tests/unit/models/submissionTest.js
+++ b/src/main/webapp/tests/unit/models/submissionTest.js
@@ -615,7 +615,17 @@ describe('model: Submission', function () {
             var fieldProfile = new mockFieldProfile(q);
             fieldProfile.optional = false;
             fieldProfile.enabled = true;
+
             model.isValid = null;
+            model.getMapping = function () {
+                return {
+                    validateFieldValue: {
+                        endpoint: "/private/queue",
+                        controller: "fake",
+                        method: "fake"
+                    }
+                };
+            };
 
             model.validate();
             scope.$apply();
@@ -625,6 +635,7 @@ describe('model: Submission', function () {
             model.fieldValues[0].fieldPredicate = new mockFieldPredicate(q);
             model.fieldValues[1].fieldPredicate = new mockFieldPredicate(q);
             model.fieldValues[1].mock(dataFieldValue2);
+            model.fieldValues[1].value = "";
             model.submissionWorkflowSteps = [ new mockWorkflowStep(q), new mockWorkflowStep(q) ];
             model.submissionWorkflowSteps[1].mock(dataWorkflowStep2);
             model.submissionWorkflowSteps[1].aggregateFieldProfiles[0] = fieldProfile;

--- a/src/test/java/org/tdl/vireo/controller/FieldValueControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/FieldValueControllerTest.java
@@ -1,0 +1,71 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.FieldPredicate;
+import org.tdl.vireo.model.FieldValue;
+import org.tdl.vireo.model.repo.FieldPredicateRepo;
+import org.tdl.vireo.model.repo.FieldValueRepo;
+
+@ActiveProfiles(value = { "test", "isolated-test" })
+public class FieldValueControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private FieldPredicateRepo fieldPredicateRepo;
+
+    @Mock
+    private FieldValueRepo fieldValueRepo;
+
+    @InjectMocks
+    private FieldValueController fieldValueController;
+
+    private FieldPredicate mockFieldPredicate1;
+
+    private FieldValue mockFieldValue1;
+    private FieldValue mockFieldValue2;
+
+    private static List<FieldValue> mockFieldValues;
+
+    @BeforeEach
+    public void setup() {
+        mockFieldValue1 = new FieldValue();
+        mockFieldValue1.setId(1L);
+        mockFieldValue1.setValue("FieldValue 1");
+
+        mockFieldValue2 = new FieldValue();
+        mockFieldValue2.setId(2L);
+        mockFieldValue2.setValue("FieldValue 2");
+
+        mockFieldPredicate1 = new FieldPredicate("FieldPredicate 1", true);
+        mockFieldPredicate1.setId(1L);
+
+        mockFieldValues = new ArrayList<FieldValue>(Arrays.asList(new FieldValue[] { mockFieldValue1 }));
+    }
+
+    @Test
+    public void testGetFieldValuesByPredicateValue() {
+        when(fieldPredicateRepo.findByValue(anyString())).thenReturn(mockFieldPredicate1);
+        when(fieldValueRepo.findAllByFieldPredicate(any(FieldPredicate.class))).thenReturn(mockFieldValues);
+
+        ApiResponse response = fieldValueController.getFieldValuesByPredicateValue("value");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ArrayList<FieldValue> fieldValues = (ArrayList<FieldValue>) response.getPayload().get("ArrayList<FieldValue>");
+        assertEquals(mockFieldValues.size(), fieldValues.size());
+        assertEquals(mockFieldValues.get(0).getId(), fieldValues.get(0).getId());
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/service/SystemDataLoaderTest.java
+++ b/src/test/java/org/tdl/vireo/service/SystemDataLoaderTest.java
@@ -492,7 +492,7 @@ public class SystemDataLoaderTest {
     }
 
     private void assertSubmissionListColumn(boolean isReload) {
-        assertEquals(60, submissionListColumnRepo.count(),
+        assertEquals(61, submissionListColumnRepo.count(),
             isReload
                 ? "Incorrect number of submissionListColumn found after reload"
                 : "Incorrect number of submissionListColumn found");


### PR DESCRIPTION
resolves #55 

This borrows heavily on the work resolved for Issue 54 (see commit cbe080bcdc4477bc1f5f8ceeff27abbf0bb94528).

Most of the field values Controller end points are under the Submission Controller rather than its own Controller. This introduces complications because the UI is using "FieldValue" and mapping it to a Submission Controller. Getting the list of FieldValues, independent of a Submission, does not belong in the Submission Controller. There are a lot of work-arounds or other unusual design changes here to accommodate this situation. A new `FieldValueRepo` is added on the UI.

This adds new functionality for selecting all Field Values associated with a given Field Predicate. This is used to select the specific Field Predicate that is hard-coded as `submission_type`.

It turns out the escape string usage in `cbe080bcdc4477bc1f5f8ceeff27abbf0bb94528` is not entirely correct. The string does need to be escaped, but not the `%` and not the `_`. Only the slashes.
Change the `escapeString()` function to handle this use case.

The **Submission Type** column already exists.
Create a new one called `Submission Type (List)`.
This exposed a problem in the design where the names of the columns are used to generate the array key names and HTML attribute names. The use of `(` and `)` is not well supported there. Break out the sanitizer used in several places into a single function call and have that function call also handle `(` and `)`. Other cases are not handled and I am leaving those to be handled on an as-needed basis. To avoid conflicts with the existing **Submission Type**, the new **Submission Type (List)** is suffixed with `List` in several places.

The `submissionListColumns` variable in the `processUpdate` of the `SubmissionListController` is being used for both the **Manage Filter Columns** and the **Submission List Columns**. This is a problem where the new `Submission Type (List)` is only a Filter and is not a Column to select. The code had to be re-worked to address this.
I chose the quick and simple approach of making another variable. There may be better ways but this seems good enough at this time.

A recent change introduced setting `$dirty` on `$scope.getSelectedOrganization()` but that did not handle the case where `$scope.getSelectedOrganization()` is undefined or NULL. This broke some unit tests but is now fixed.

Update the CLI tests to generate Submission Types that are not always different. The Submission Type is created outside of the transaction loop to ensure only a small set is created. If there already exists Submission Types then no new ones are created and the existing ones are re-used. This allows for building generated test data on a system with existing data already populated.