### PR TITLE
Improve performance of CLI generate.

### DIFF
--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -127,7 +127,7 @@ public class Cli implements CommandLineRunner {
 
                         {
                             Random random = new Random();
-                            int idOffset = cliService.countUsers();
+                            long idOffset = cliService.countUsers();
                             User helpfulHarry = null;
                             boolean hasSubmissionTypes = false;
 
@@ -136,7 +136,7 @@ public class Cli implements CommandLineRunner {
                                 hasSubmissionTypes = cliService.hasSubmissionTypes();
                             }
 
-                            for (int i = itemsGenerated; i < num1 + itemsGenerated; i++) {
+                            for (long i = itemsGenerated; i < num1 + itemsGenerated; i++) {
                                 cliService.operateGenerate(expansive, num2, random, idOffset, helpfulHarry, hasSubmissionTypes, i);
                                 System.out.print("\r" + (i - itemsGenerated) + " of " + num1 + " generated...");
                             }

--- a/src/main/java/org/tdl/vireo/service/CliService.java
+++ b/src/main/java/org/tdl/vireo/service/CliService.java
@@ -119,7 +119,7 @@ public class CliService {
         return fieldValueRepo.findAllByFieldPredicate(submissionTypeFP).size() > 0;
     }
 
-    public void operateGenerate(boolean expansive, int maxActionLogs, Random random, int idOffset, User helpfulHarry, boolean hasSubmissionTypes, int i) throws OrganizationDoesNotAcceptSubmissionsException {
+    public void operateGenerate(boolean expansive, int maxActionLogs, Random random, long idOffset, User helpfulHarry, boolean hasSubmissionTypes, long i) throws OrganizationDoesNotAcceptSubmissionsException {
         Calendar now = Calendar.getInstance();
         User submitter = userRepo.create("bob" + EMAIL_DATE.format(now.getTime()) + (idOffset + i + 1) + "@boring.bob", "bob", "boring " + (idOffset + i + 1), Role.ROLE_STUDENT);
         Credentials credentials = new Credentials();
@@ -331,8 +331,8 @@ public class CliService {
         submissionRepo.saveAndFlush(sub);
     }
 
-    public int countUsers() {
-        return userRepo.findAll().toArray().length;
+    public long countUsers() {
+        return userRepo.count();
     }
 
     public void setAcceptSubmissions(Organization organization) {
@@ -342,7 +342,7 @@ public class CliService {
         }
     }
 
-    public User createHelpfulHarry(int offset, SimpleDateFormat formatter) {
+    public User createHelpfulHarry(long offset, SimpleDateFormat formatter) {
         String dateString = formatter.format(Calendar.getInstance().getTime());
         return userRepo.create("harry" + dateString + offset + "@help.ful", "Harry", "Helpful " + offset, Role.ROLE_REVIEWER);
     }


### PR DESCRIPTION
Doing a `findAll()` and then counting the length of the array is highly enefficient.
Using `findAll()` slowing down the generation of large data sets for testing.
Change the code to an SQL count via the JPA `count()` method.