### PR TITLE
Issue 55: Use a explicit Query for fetching the Submission Type list.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/FieldValueController.java
+++ b/src/main/java/org/tdl/vireo/controller/FieldValueController.java
@@ -22,9 +22,6 @@ import org.tdl.vireo.model.repo.FieldValueRepo;
 public class FieldValueController {
 
     @Autowired
-    private FieldPredicateRepo fieldPredicateRepo;
-
-    @Autowired
     private FieldValueRepo fieldValueRepo;
 
     /**
@@ -37,8 +34,7 @@ public class FieldValueController {
     @GetMapping("/predicate/{value}")
     @PreAuthorize("hasRole('STUDENT')")
     public ApiResponse getFieldValuesByPredicateValue(@PathVariable String value) {
-        final FieldPredicate fieldPredicate = fieldPredicateRepo.findByValue(value);
-        return new ApiResponse(SUCCESS, fieldValueRepo.findAllByFieldPredicate(fieldPredicate));
+        return new ApiResponse(SUCCESS, fieldValueRepo.getAllValuesByFieldPredicateValue("submission_type"));
     }
 
 }

--- a/src/main/java/org/tdl/vireo/model/repo/FieldValueRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/FieldValueRepo.java
@@ -1,14 +1,9 @@
 package org.tdl.vireo.model.repo;
 
-import org.tdl.vireo.model.FieldPredicate;
+import edu.tamu.weaver.data.model.repo.WeaverRepo;
 import org.tdl.vireo.model.FieldValue;
 import org.tdl.vireo.model.repo.custom.FieldValueRepoCustom;
 
-import edu.tamu.weaver.data.model.repo.WeaverRepo;
-import java.util.List;
-
 public interface FieldValueRepo extends WeaverRepo<FieldValue>, FieldValueRepoCustom {
-
-    public List<FieldValue> findAllByFieldPredicate(FieldPredicate fieldPredicate);
 
 }

--- a/src/main/java/org/tdl/vireo/model/repo/custom/FieldValueRepoCustom.java
+++ b/src/main/java/org/tdl/vireo/model/repo/custom/FieldValueRepoCustom.java
@@ -1,10 +1,13 @@
 package org.tdl.vireo.model.repo.custom;
 
+import java.util.List;
 import org.tdl.vireo.model.FieldPredicate;
 import org.tdl.vireo.model.FieldValue;
 
 public interface FieldValueRepoCustom {
 
     public FieldValue create(FieldPredicate fieldPredicate);
+
+    public List<String> getAllValuesByFieldPredicateValue(String fieldPredicateValue);
 
 }

--- a/src/main/java/org/tdl/vireo/model/repo/impl/FieldValueRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/FieldValueRepoImpl.java
@@ -1,17 +1,29 @@
 package org.tdl.vireo.model.repo.impl;
 
+import edu.tamu.weaver.data.model.repo.impl.AbstractWeaverRepoImpl;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.tdl.vireo.model.FieldPredicate;
 import org.tdl.vireo.model.FieldValue;
 import org.tdl.vireo.model.repo.FieldValueRepo;
 import org.tdl.vireo.model.repo.custom.FieldValueRepoCustom;
 
-import edu.tamu.weaver.data.model.repo.impl.AbstractWeaverRepoImpl;
-
 public class FieldValueRepoImpl extends AbstractWeaverRepoImpl<FieldValue, FieldValueRepo> implements FieldValueRepoCustom {
+
+    final static String VALUES_BY_PREDICATE = "SELECT DISTINCT fv.value AS value FROM field_value fv WHERE fv.field_predicate_id IN " +
+                                              "(SELECT fp.id FROM field_predicate fp WHERE fp.value = ?) ORDER BY fv.value ASC";
 
     @Autowired
     private FieldValueRepo fieldValueRepo;
+
+    private JdbcTemplate jdbcTemplate;
+
+    public FieldValueRepoImpl(DataSource dataSource) {
+        jdbcTemplate = new JdbcTemplate(dataSource);
+    }
 
     @Override
     public FieldValue create(FieldPredicate fieldPredicate) {
@@ -21,6 +33,18 @@ public class FieldValueRepoImpl extends AbstractWeaverRepoImpl<FieldValue, Field
     @Override
     protected String getChannel() {
         return "/channel/field-value";
+    }
+
+    @Override
+    public List<String> getAllValuesByFieldPredicateValue(String fieldPredicateValue) {
+        String query = "SELECT DISTINCT fv.value AS value FROM field_value fv WHERE fv.field_predicate_id IN (select fp.id FROM field_predicate fp WHERE fp.value = ?) ORDER BY fv.value ASC";
+
+        List<String> list = new ArrayList<>();
+        jdbcTemplate.queryForList(VALUES_BY_PREDICATE, fieldPredicateValue).forEach(row -> {
+            list.add((String) row.get("value"));
+        });
+
+        return list;
     }
 
 }

--- a/src/main/java/org/tdl/vireo/model/repo/impl/FieldValueRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/FieldValueRepoImpl.java
@@ -37,8 +37,6 @@ public class FieldValueRepoImpl extends AbstractWeaverRepoImpl<FieldValue, Field
 
     @Override
     public List<String> getAllValuesByFieldPredicateValue(String fieldPredicateValue) {
-        String query = "SELECT DISTINCT fv.value AS value FROM field_value fv WHERE fv.field_predicate_id IN (select fp.id FROM field_predicate fp WHERE fp.value = ?) ORDER BY fv.value ASC";
-
         List<String> list = new ArrayList<>();
         jdbcTemplate.queryForList(VALUES_BY_PREDICATE, fieldPredicateValue).forEach(row -> {
             list.add((String) row.get("value"));

--- a/src/main/java/org/tdl/vireo/service/CliService.java
+++ b/src/main/java/org/tdl/vireo/service/CliService.java
@@ -115,8 +115,7 @@ public class CliService {
     }
 
     public boolean hasSubmissionTypes() {
-        FieldPredicate submissionTypeFP = fieldPredicateRepo.findByValue("submission_type");
-        return fieldValueRepo.findAllByFieldPredicate(submissionTypeFP).size() > 0;
+        return fieldValueRepo.getAllValuesByFieldPredicateValue("submission_type").size() > 0;
     }
 
     public void operateGenerate(boolean expansive, int maxActionLogs, Random random, int idOffset, User helpfulHarry, boolean hasSubmissionTypes, int i) throws OrganizationDoesNotAcceptSubmissionsException {
@@ -138,7 +137,7 @@ public class CliService {
         final List<VocabularyWord> departmentsVW = new ArrayList<>();
         final List<VocabularyWord> schoolsVW = new ArrayList<>();
         final List<VocabularyWord> majorsVW = new ArrayList<>();
-        final List<FieldValue> submissionTypesVW = new ArrayList<>();
+        final List<String> submissionTypeValues = new ArrayList<>();
         Organization org = orgs.get(getRandomNumber(organizationRepo.findAll().size()));
         SubmissionStatus state = statuses.get(0);
         setAcceptSubmissions(org);
@@ -158,9 +157,8 @@ public class CliService {
         });
 
         if (hasSubmissionTypes) {
-            FieldPredicate submissionTypeFP = fieldPredicateRepo.findByValue("submission_type");
-            fieldValueRepo.findAllByFieldPredicate(submissionTypeFP).forEach((FieldValue fv) -> {
-                submissionTypesVW.add(fv);
+            fieldValueRepo.getAllValuesByFieldPredicateValue("submission_type").forEach((String value) -> {
+                submissionTypeValues.add(value);
             });
         }
 
@@ -310,15 +308,15 @@ public class CliService {
                         val.setContacts(Arrays.asList(new String[] { "test" + pred.getValue() + i + AT_ADDRESS }));
                         sub.addFieldValue(val);
                     } else if (pred.getValue().equalsIgnoreCase("submission_type")) {
-                        FieldValue fv = null;
-                        if (submissionTypesVW.size() > 0) {
-                            fv = submissionTypesVW.get(getRandomNumber(submissionTypesVW.size()));
+                        String value = null;
+                        if (submissionTypeValues.size() > 0) {
+                            value = submissionTypeValues.get(getRandomNumber(submissionTypeValues.size()));
                         }
 
-                        if (fv == null) {
+                        if (value == null) {
                             val.setValue("test " + pred.getValue() + " " + getRandomNumber(10));
                         } else {
-                            val.setValue(fv.getValue());
+                            val.setValue(value);
                         }
                     } else {
                         val.setValue("test " + pred.getValue() + " " + i);

--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -216,7 +216,7 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
         var embargos = EmbargoRepo.getAll();
         var packagers = PackagerRepo.getAll();
         var controlledVocabularies = ControlledVocabularyRepo.getAll();
-        var submissionTypeList = FieldValueRepo.findByPredicateValue('submission_type');
+        var submissionTypeList = FieldValueRepo.findValuesByPredicateValue('submission_type');
 
         var addBatchCommentEmail = function (message) {
             batchCommentEmail.adding = true;

--- a/src/main/webapp/app/filters/uniqueSubmissionTypeList.js
+++ b/src/main/webapp/app/filters/uniqueSubmissionTypeList.js
@@ -3,13 +3,14 @@ vireo.filter('uniqueSubmissionTypeList', function() {
     var matched = [];
     var newValues = [];
     if (typeof initialValues === 'object') {
-      angular.forEach(initialValues, function(fv) {
-        if (matched.includes(fv.value)) return;
+      angular.forEach(initialValues, function(value) {
+        if (matched.includes(value)) return;
 
-        matched.push(fv.value);
-        newValues.push(fv);
+        matched.push(value);
+        newValues.push(value);
       });
     }
+
     return newValues;
   };
 });

--- a/src/main/webapp/app/repo/fieldValueRepo.js
+++ b/src/main/webapp/app/repo/fieldValueRepo.js
@@ -2,7 +2,7 @@ vireo.repo("FieldValueRepo", function FieldValueRepo(FieldValue, WsApi) {
 
   var fieldValueRepo = this;
 
-  fieldValueRepo.findByPredicateValue = function(value) {
+  fieldValueRepo.findValuesByPredicateValue = function(value) {
       var fieldValues = [];
 
       // FieldValue exists on the API Mapping but is under the Submission controller, which is not correct and so manually define the entire mapping inline here.
@@ -16,9 +16,9 @@ vireo.repo("FieldValueRepo", function FieldValueRepo(FieldValue, WsApi) {
           if (!!res && !!res.body) {
             var resObj = angular.fromJson(res.body);
             if (resObj.meta.status === 'SUCCESS') {
-                var values = resObj.payload['ArrayList<FieldValue>'];
+                var values = resObj.payload['ArrayList<String>'];
                 for (var i in values) {
-                    fieldValues.push(new FieldValue(values[i]));
+                    fieldValues.push(values[i]);
                 }
             }
           }

--- a/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterBySubmissionTypeList.html
+++ b/src/main/webapp/app/views/sideboxes/furtherFilterBy/furtherFilterBySubmissionTypeList.html
@@ -1,5 +1,5 @@
 <form name="{{'box.SubmissionTypeListForm'}}">
   <ul class="sidebox-list">
-    <li class="filter" ng-click="box.SubmissionTypeList=st.value;box.addExactMatchFilter(column);" ng-repeat="st in box.submissionTypeList | uniqueSubmissionTypeList">{{st.value}}</li>
+    <li class="filter" ng-click="box.SubmissionTypeList=st;box.addExactMatchFilter(column);" ng-repeat="st in box.submissionTypeList | uniqueSubmissionTypeList">{{st}}</li>
   </ul>
 </form>

--- a/src/test/java/org/tdl/vireo/controller/FieldValueControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/FieldValueControllerTest.java
@@ -1,7 +1,6 @@
 package org.tdl.vireo.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -37,7 +36,7 @@ public class FieldValueControllerTest extends AbstractControllerTest {
     private FieldValue mockFieldValue1;
     private FieldValue mockFieldValue2;
 
-    private static List<FieldValue> mockFieldValues;
+    private static List<String> mockValues;
 
     @BeforeEach
     public void setup() {
@@ -52,20 +51,19 @@ public class FieldValueControllerTest extends AbstractControllerTest {
         mockFieldPredicate1 = new FieldPredicate("FieldPredicate 1", true);
         mockFieldPredicate1.setId(1L);
 
-        mockFieldValues = new ArrayList<FieldValue>(Arrays.asList(new FieldValue[] { mockFieldValue1 }));
+        mockValues = new ArrayList<String>(Arrays.asList(new String[] { mockFieldValue1.getValue() }));
     }
 
     @Test
     public void testGetFieldValuesByPredicateValue() {
-        when(fieldPredicateRepo.findByValue(anyString())).thenReturn(mockFieldPredicate1);
-        when(fieldValueRepo.findAllByFieldPredicate(any(FieldPredicate.class))).thenReturn(mockFieldValues);
+        when(fieldValueRepo.getAllValuesByFieldPredicateValue(anyString())).thenReturn(mockValues);
 
         ApiResponse response = fieldValueController.getFieldValuesByPredicateValue("value");
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        ArrayList<FieldValue> fieldValues = (ArrayList<FieldValue>) response.getPayload().get("ArrayList<FieldValue>");
-        assertEquals(mockFieldValues.size(), fieldValues.size());
-        assertEquals(mockFieldValues.get(0).getId(), fieldValues.get(0).getId());
+        ArrayList<String> fieldValues = (ArrayList<String>) response.getPayload().get("ArrayList<String>");
+        assertEquals(mockValues.size(), fieldValues.size());
+        assertEquals(mockValues.get(0), fieldValues.get(0));
     }
 
 }


### PR DESCRIPTION
Relates #55

The test data consisted of randomly generated data with:
- 44075 submissions.
- 1458591 field values.

The submission list page took ~3.5 minutes to load the Submission Type list data.
Switching to an explicit query, the submission list page took ~320 milliseconds to load the Submission Type list data.

This is an overwhelming clear improvement that shows that the use of Spring+JPA internals are highly inefficient for the Field Values and related data.
For the filters, the actual model does not need to be loaded and only the value.

The use of a JDBC query is chosen after doing tests against Postgresql and H2.
The use of a native query via `@Query` worked for Postgresql but H2 used clob2 and failed to convert the results into strings.
Using a literal query is chosen over a JPA query because the JPA wants to understand the model structure.
The Field Predicate is not loaded immediately available for JPA for the FieldValue JPA Repository.

Only very basic SQL is used in the query and so there should be very little SQL compatibility risks.
The biggest risk is that of the table naming structure.
This structure appears to be sufficiently consistent between Postgresql and H2 in this regard.

**Spring+JPA Performance:**
![test_data-44075_subm-1458591_fv-jpa-Screenshot_2024-04-29_09-21-09](https://github.com/TAMULib/Vireo/assets/35114839/8a01723c-fef3-4d53-afd1-5effabbb7fdd)

**JDBC Performance:**
![test_data-44075_subm-1458591_fv-jdbc-Screenshot_2024-04-29_09-21-09](https://github.com/TAMULib/Vireo/assets/35114839/3f8880b0-0c84-432e-8a86-3da79c9a3cbc)

