### PR TITLE
Make the Embargo Type and Submission Type `None` values configurable.

### DIFF
--- a/src/main/java/org/tdl/vireo/config/AppFilterConfig.java
+++ b/src/main/java/org/tdl/vireo/config/AppFilterConfig.java
@@ -1,0 +1,30 @@
+package org.tdl.vireo.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "app.filter")
+public class AppFilterConfig {
+
+    private String embargoTypeNone;
+
+    private String submissionTypeNone;
+
+    public String getEmbargoTypeNone() {
+        return embargoTypeNone;
+    }
+
+    public void setEmbargoTypeNone(String embargoTypeNone) {
+        this.embargoTypeNone = embargoTypeNone;
+    }
+
+    public String getSubmissionTypeNone() {
+        return submissionTypeNone;
+    }
+
+    public void setSubmissionTypeNone(String submissionTypeNone) {
+        this.submissionTypeNone = submissionTypeNone;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -36,6 +36,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.transaction.annotation.Transactional;
+import org.tdl.vireo.config.AppFilterConfig;
 import org.tdl.vireo.config.VireoDatabaseConfig;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsException;
 import org.tdl.vireo.model.Configuration;
@@ -100,6 +101,9 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
     @Autowired
     private AssetService assetService;
+
+    @Autowired
+    private AppFilterConfig appFilterConfig;
 
     @Autowired
     private VireoDatabaseConfig vireoDatabaseConfig;
@@ -752,7 +756,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                                 sqlBuilder.append(" value = '").append(escapeString(filterString, false, true)).append("' OR");
                             }
 
-                            if ("None".equals(filterString)) {
+                            if (appFilterConfig.getEmbargoTypeNone().equalsIgnoreCase(filterString)) {
                                 hasNone = true;
                             }
                         }
@@ -782,7 +786,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                                 sqlBuilder.append(" value = '").append(escapeString(filterString, false, true)).append("' OR");
                             }
 
-                            if ("None".equals(filterString)) {
+                            if (appFilterConfig.getSubmissionTypeNone().equalsIgnoreCase(filterString)) {
                                 hasNone = true;
                             }
                         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -166,6 +166,13 @@ app:
   # edu.tamu.weaver.utility.HttpUtility
   http.timeout: 10000
 
+  # org.tdl.vireo.config.AppFilterConfig
+  filter:
+    # The "*TypeNone" represent this value and having a NULL value being treated as the same.
+    # These are often something like "None", "Unassigned", or "Unknown".
+    embargoTypeNone: None
+    submissionTypeNone: None
+
 # edu.tamu.weaver.token.service.TokenService
 auth:
   security.jwt:


### PR DESCRIPTION
Relates #54
Relates #55

The behavior of the case of `None` is treated as as synonymous with a NULL value for that field in the database. I've looked over the different use cases and have found that in some cases `Unknown` and `Unassigned` are used.

Make this `None` filter value customizable rather than hard-coding the opinion of `None` being NULL.

The `app.filter.embargoTypeNone` and `app.filter.submissionTypeNone` may now be changed to something other than `None`. The default remains set to `None`.