### PR TITLE
Avoid excessive auto-subscription of Submission listeners.

### DIFF
--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -78,6 +78,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
     SubmissionRepo.fetchSubmissionById($routeParams.id).then(function(submission) {
 
         $scope.submission = submission;
+        $scope.submission.enableListeners();
 
         $scope.loaded = true;
 

--- a/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
+++ b/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
@@ -19,6 +19,7 @@ vireo.controller("AdvisorSubmissionReviewController", function ($controller, $sc
     AdvisorSubmissionRepo.fetchSubmissionByHash($routeParams.advisorAccessHash).then(function (submission) {
         $scope.advisorSubmissionRepoReady = true;
         $scope.submission = submission;
+        $scope.submission.enableListeners();
         resetApproveProxy();
         $scope.submission.fetchDocumentTypeFileInfo();
     });

--- a/src/main/webapp/app/controllers/submission/studentSubmissionController.js
+++ b/src/main/webapp/app/controllers/submission/studentSubmissionController.js
@@ -15,6 +15,7 @@ vireo.controller("StudentSubmissionController", function ($controller, $scope, $
         $scope.studentSubmissionRepoReady = true;
 
         $scope.submission = submission;
+        $scope.submission.enableListeners();
 
         $scope.submission.fetchDocumentTypeFileInfo();
 

--- a/src/main/webapp/app/controllers/submission/submissionHistoryController.js
+++ b/src/main/webapp/app/controllers/submission/submissionHistoryController.js
@@ -27,14 +27,35 @@ vireo.controller('SubmissionHistoryController', function ($controller, $location
 
     var manuscriptFetchLock = {};
 
+    var handleResponse = function (res) {
+        if (!!res && !!res.body) {
+            var apiRes = angular.fromJson(res.body);
+            if (apiRes.meta.status === "SUCCESS") {
+                resetTable();
+            }
+        }
+    };
+
     StudentSubmissionRepo.ready().then(function () {
+        angular.forEach($scope.studentsSubmissions, function (submission) {
+            if (!!submission) {
+                submission.enableListeners(true);
+
+                if (!!submission.fieldValuesListenPromise) {
+                    submission.fieldValuesListenPromise.then(null, null, handleResponse);
+                }
+
+                if (!!submission.fieldValuesRemovedListenPromise) {
+                    submission.fieldValuesRemovedListenPromise.then(null, null, handleResponse);
+                }
+            }
+        });
+
         resetTable();
     });
 
-    StudentSubmissionRepo.listenForChanges().then(null, null, function() {
-        StudentSubmissionRepo.reset().then(function() {
-            resetTable();
-        });
+    StudentSubmissionRepo.listenForChanges().then(null, null, function(res) {
+        StudentSubmissionRepo.reset().then(handleResponse);
     });
 
     $scope.getDocumentTitle = function (row) {

--- a/src/main/webapp/app/controllers/submission/submissionHistoryController.js
+++ b/src/main/webapp/app/controllers/submission/submissionHistoryController.js
@@ -27,7 +27,7 @@ vireo.controller('SubmissionHistoryController', function ($controller, $location
 
     var manuscriptFetchLock = {};
 
-    var handleResponse = function (res) {
+    var resetTableOnSuccessResponse = function (res) {
         if (!!res && !!res.body) {
             var apiRes = angular.fromJson(res.body);
             if (apiRes.meta.status === "SUCCESS") {
@@ -42,11 +42,11 @@ vireo.controller('SubmissionHistoryController', function ($controller, $location
                 submission.enableListeners(true);
 
                 if (!!submission.fieldValuesListenPromise) {
-                    submission.fieldValuesListenPromise.then(null, null, handleResponse);
+                    submission.fieldValuesListenPromise.then(null, null, resetTableOnSuccessResponse);
                 }
 
                 if (!!submission.fieldValuesRemovedListenPromise) {
-                    submission.fieldValuesRemovedListenPromise.then(null, null, handleResponse);
+                    submission.fieldValuesRemovedListenPromise.then(null, null, resetTableOnSuccessResponse);
                 }
             }
         });
@@ -55,7 +55,12 @@ vireo.controller('SubmissionHistoryController', function ($controller, $location
     });
 
     StudentSubmissionRepo.listenForChanges().then(null, null, function(res) {
-        StudentSubmissionRepo.reset().then(handleResponse);
+        if (!!res && !!res.body) {
+            var apiRes = angular.fromJson(res.body);
+            if (apiRes.meta.status === "SUCCESS") {
+                StudentSubmissionRepo.reset().then(resetTableOnSuccessResponse);
+            }
+        }
     });
 
     $scope.getDocumentTitle = function (row) {

--- a/src/main/webapp/app/controllers/submission/submissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/submissionViewController.js
@@ -24,6 +24,7 @@ vireo.controller("SubmissionViewController", function ($controller, $q, $scope, 
         StudentSubmissionRepo.fetchSubmissionById($routeParams.submissionId).then(function (submission) {
             $scope.loaded = true;
             $scope.submission = submission;
+            $scope.submission.enableListeners();
             $scope.submission.fetchDocumentTypeFileInfo();
         });
 

--- a/src/main/webapp/tests/mocks/models/mockStudentSubmission.js
+++ b/src/main/webapp/tests/mocks/models/mockStudentSubmission.js
@@ -136,6 +136,15 @@ var mockStudentSubmission = function($q) {
         return payloadPromise($q.defer());
     };
 
+    model.enableListeners = function (simple) {
+        model.actionLogListenPromise = $q.defer().promise;
+        model.customActionValuesListenPromise = $q.defer().promise;
+        model.fieldValuesListenPromise = $q.defer().promise;
+        model.fieldValuesRemovedListenPromise = $q.defer().promise;
+
+        model.actionLogListenReloadDefer = $q.defer();
+    };
+
     model.fetchDocumentTypeFileInfo = function () {
     };
 

--- a/src/main/webapp/tests/mocks/models/mockStudentSubmission.js
+++ b/src/main/webapp/tests/mocks/models/mockStudentSubmission.js
@@ -137,12 +137,15 @@ var mockStudentSubmission = function($q) {
     };
 
     model.enableListeners = function (simple) {
-        model.actionLogListenPromise = $q.defer().promise;
-        model.customActionValuesListenPromise = $q.defer().promise;
         model.fieldValuesListenPromise = $q.defer().promise;
         model.fieldValuesRemovedListenPromise = $q.defer().promise;
 
-        model.actionLogListenReloadDefer = $q.defer();
+        if (simple !== true) {
+            model.actionLogListenPromise = $q.defer().promise;
+            model.customActionValuesListenPromise = $q.defer().promise;
+
+            model.actionLogListenReloadDefer = $q.defer();
+        }
     };
 
     model.fetchDocumentTypeFileInfo = function () {

--- a/src/main/webapp/tests/mocks/models/mockSubmission.js
+++ b/src/main/webapp/tests/mocks/models/mockSubmission.js
@@ -327,6 +327,18 @@ var mockSubmission = function($q) {
         return payloadPromise($q.defer());
     };
 
+    model.enableListeners = function (simple) {
+        model.fieldValuesListenPromise = $q.defer().promise;
+        model.fieldValuesRemovedListenPromise = $q.defer().promise;
+
+        if (simple !== true) {
+            model.actionLogListenPromise = $q.defer().promise;
+            model.customActionValuesListenPromise = $q.defer().promise;
+
+            model.actionLogListenReloadDefer = $q.defer();
+        }
+    };
+
     model.fetchDocumentTypeFileInfo = function () {
     };
 

--- a/src/main/webapp/tests/unit/controllers/submission/submissionHistoryControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/submissionHistoryControllerTest.js
@@ -1,12 +1,15 @@
 describe("controller: SubmissionHistoryController", function () {
 
-    var controller, location, q, scope, timeout, NgTableParams, WsApi;
+    var controller, location, q, scope, timeout, MockedSubmission, MockedStudentSubmission, NgTableParams, WsApi;
 
     var initializeVariables = function(settings) {
         inject(function ($location, $q, $timeout, _WsApi_) {
             location = $location;
             q = $q;
             timeout = $timeout;
+
+            MockedStudentSubmission = new mockStudentSubmission($q);
+            MockedSubmission = new mockSubmission($q);
 
             NgTableParams = mockNgTableParams;
             WsApi = _WsApi_;
@@ -49,6 +52,18 @@ describe("controller: SubmissionHistoryController", function () {
         module("mock.restApi");
         module("mock.storageService");
         module("mock.studentSubmission");
+        module("mock.submission", function ($provide) {
+          var Submission = function () {
+            return MockedSubmission;
+          };
+          $provide.value("Submission", Submission);
+        });
+        module("mock.studentSubmission", function ($provide) {
+          var StudentSubmission = function () {
+            return MockedStudentSubmission;
+          };
+          $provide.value("StudentSubmission", StudentSubmission);
+        });
         module("mock.studentSubmissionRepo");
         module("mock.wsApi");
 


### PR DESCRIPTION
The `Submission` model in the **UI** is adding 4 or more listeners on instantiation. This causes every open browser to receive an auto-subscription for every newly created `Submission`. Then for every change done, the browsers receive this.

This is particularly bad when:
1. The current browser page has nothing related to the newly added or recently modified `Submission`.
2. Numerous `Submissions` are created while a given browser page is open.
3. Numerous already subscribed `Submissions` are updated while a given browser page is open.

The browser resources become excessively used and abused, slowing down the performance and response time of a browser. Reloading the page is often the only way to clean this up.

This redesigns the `Submission` model to move the subscription into a manually called function (`enableListeners()`). This `enableListeners()` function is then explicitly called for all cases where a `Submission` should be listened to.

The `enableListeners()` function accepts an argument called `simple` that when true loads a reduced set of the standard `Submission` listeners. This is useful for pages that only care about basic information and not detailed information. This should help reduce the burden on the browser and potentially increase performance.

A review of the list table shows that the list table already does not update dynamically. No changes are made to make the list table update dynamically.

These changes partially resolves https://github.com/TexasDigitalLibrary/Vireo/issues/1885 . The removed listener is present but when a remove is performed the page does not refresh.

The following are places that have been tested and should be tested:
- Student Submission Page
- Admin Submission Page
- Student Submission Review Page.
- Faculty Reviewer Submission Page.
- The Manage/View Submission Page (Submission Hisory Page).
- Welcome Page (should no longer have "subscription" messages in console log).
- Admin Submission List Page (should no longer have "subscription" messages in console log).

The "Welcome Page" and the "Admin Submission List Page" are not expected to update on changes. The others should be reviewed to confirm that the Submission changes are updated while edited in another webbrowser page.

A `Submission.disableListneers()` function might be useful.

Example addition to the submission:
```js
        submission.disableListeners = function (simple) {
            if (angular.isUndefined(submission.id)) {
                return;
            }

            var fieldValuesListen = apiMapping.Submission.fieldValuesListen;
            var fieldValuesRemovedListen = apiMapping.Submission.fieldValueRemovedListen;

            WsService.unsubscribe(fieldValuesListen.endpoint + "/" + fieldValuesListen.controller + "/" + submission.id + "/field-values");
            WsService.unsubscribe(fieldValuesRemovedListen.endpoint + "/" + fieldValuesRemovedListen.controller + "/" + submission.id + "/removed-field-values");

            delete submission.fieldValuesListenPromise;
            delete submission.fieldValuesRemovedListenPromise;

            if (simple !== true) {
                var actionLogListen = apiMapping.Submission.actionLogListen;
                var customActionValuesListen = apiMapping.Submission.customActionValuesListen;

                WsService.unsubscribe(fieldValuesListen.endpoint + "/" + fieldValuesListen.controller + "/" + submission.id + "/action-logs");
                WsService.unsubscribe(fieldValuesRemovedListen.endpoint + "/" + fieldValuesRemovedListen.controller + "/" + submission.id + "/custom-action-values");

                delete submission.actionLogListenPromise;
                delete submission.customActionValuesListenPromise;

                delete submission.actionLogListenReloadDefer;
            }
        };
```

Example addition to the mocks:
```js
    model.disableListeners = function (simple) {
        delete model.fieldValuesListenPromise;
        delete model.fieldValuesRemovedListenPromise;

        if (simple !== true) {
            delete model.actionLogListenPromise;
            delete model.customActionValuesListenPromise;

            delete model.actionLogListenReloadDefer;
        }
    };
```