### PR TITLE
Fix Test failure regarding EmailRecipientContactTest file.

### DIFF
--- a/src/test/java/org/tdl/vireo/model/EmailRecipientContactTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmailRecipientContactTest.java
@@ -3,6 +3,7 @@ package org.tdl.vireo.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -40,10 +41,11 @@ public class EmailRecipientContactTest extends AbstractModelTest<EmailRecipientC
         fieldValues.add(fieldValue);
         fieldValues.add(otherFieldValue);
         fieldPredicate.setId(1L);
+        fieldPredicate.setValue("fp_value");
 
         ReflectionTestUtils.setField(emailRecipientContact, "fieldPredicate", fieldPredicate);
 
-        when(submission.getFieldValuesByPredicate(any(FieldPredicate.class))).thenReturn(fieldValues);
+        when(submission.getFieldValuesByPredicateValue(anyString())).thenReturn(fieldValues);
 
         List<String> got = emailRecipientContact.getEmails(submission);
 


### PR DESCRIPTION
The error:
```
[ERROR] Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0 s <<< FAILURE! - in org.tdl.vireo.model.EmailRecipientContactTest
[ERROR] testGetEmails  Time elapsed: 0 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: Emails array does not have the correct length. ==> expected: <0> but was: <2>
	at org.tdl.vireo.model.EmailRecipientContactTest.testGetEmails(EmailRecipientContactTest.java:50)
```

This PR and commit:
- https://github.com/TexasDigitalLibrary/Vireo/pull/1923
- https://github.com/TexasDigitalLibrary/Vireo/commit/7b4a7b8c1ab66df89f42f40148291b4a88011ee7

Did not also update the unit test.

This updates the unit test to now mock `getFieldValuesByPredicateValue()` instead of mocking `getFieldValuesByPredicate()`.

You may want to instead merge this into the base branch to avoid having to always deal with the failing test.
If that is the case, then I or some one else may change the merge into branch to `sprint2` rather than `sprint2-staging`.