### PR TITLE
Update credentials service to respect shibboleth configurations

### DIFF
--- a/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
+++ b/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
@@ -3,10 +3,10 @@ package org.tdl.vireo.auth.service;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.tdl.vireo.config.constant.ConfigurationName;
 import org.tdl.vireo.model.Role;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.ConfigurationRepo;
@@ -18,87 +18,114 @@ import edu.tamu.weaver.auth.service.UserCredentialsService;
 @Service
 public class VireoUserCredentialsService extends UserCredentialsService<User, UserRepo> {
 
+    private static final String NETID = "APPLICATION_AUTH_SHIB_ATTRIBUTE_NETID";
+    private static final String EMAIL = "APPLICATION_AUTH_SHIB_ATTRIBUTE_EMAIL";
+    private static final String BIRTH_YEAR = "APPLICATION_AUTH_SHIB_ATTRIBUTE_BIRTH_YEAR";
+    private static final String MIDDLE_NAME = "APPLICATION_AUTH_SHIB_ATTRIBUTE_MIDDLE_NAME";
+    private static final String ORCID = "APPLICATION_AUTH_SHIB_ATTRIBUTE_ORCID";
+    private static final String INSTITUTIONAL_IDENTIFIER = "APPLICATION_AUTH_SHIB_ATTRIBUTE_INSTITUTIONAL_IDENTIFIER";
+    private static final String SHIBBOLETH = "shibboleth";
+
+    private static final Map<String, String> shibSettings = new HashMap<>();
+
+    static {
+        shibSettings.put(NETID, "netid");
+        shibSettings.put(EMAIL, "email");
+        shibSettings.put(BIRTH_YEAR, "birthYear");
+        shibSettings.put(MIDDLE_NAME, "middleName");
+        shibSettings.put(ORCID, "orcid");
+        shibSettings.put(INSTITUTIONAL_IDENTIFIER, "uin");
+    }
+
     @Autowired
     private ConfigurationRepo configurationRepo;
 
-    @Value("${app.useNetIdAsIdentifier:false}")
-    private boolean useNetIdAsIdentifier;
+    @Value("${app.useNetidAsIdentifier:false}")
+    private boolean useNetidAsIdentifier;
 
     @Override
     public synchronized User updateUserByCredentials(Credentials credentials) {
-        User user = useNetIdAsIdentifier
-            ? userRepo.findByNetid(credentials.getNetid())
-            : userRepo.findByEmail(credentials.getEmail());
+        Map<String, String> shibValues = new HashMap<>();
 
-        Map<String, String> shibSettings = new HashMap<String, String>();
-        Map<String, String> shibValues = new HashMap<String, String>();
+        shibSettings.forEach((k, v) ->
+            shibValues.put(k, configurationRepo.getValueByNameAndType(k, SHIBBOLETH) != null ? configurationRepo.getValueByNameAndType(k, SHIBBOLETH) : v)
+        );
 
-        shibSettings.put(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_NETID, "netid");
-        shibSettings.put(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_BIRTH_YEAR, "birthYear");
-        shibSettings.put(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_MIDDLE_NAME, "middleName");
-        shibSettings.put(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_ORCID, "orcid");
-        shibSettings.put(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_INSTITUTIONAL_IDENTIFIER, "uin");
+        String shibNetid = credentials.getAllCredentials().get(shibValues.get(NETID));
+        String shibEmail = credentials.getAllCredentials().get(shibValues.get(EMAIL));
+        String shibMiddleName = credentials.getAllCredentials().get(shibValues.get(MIDDLE_NAME));
+        String shibOrcid = credentials.getAllCredentials().get(shibValues.get(ORCID));
 
-        shibSettings.forEach((k, v) -> {
-            shibValues.put(k, configurationRepo.getValueByNameAndType(k, "shibboleth") != null ? configurationRepo.getValueByNameAndType(k, "shibboleth") : v);
-        });
+        User user = useNetidAsIdentifier
+            ? userRepo.findByNetid(shibNetid)
+            : userRepo.findByEmail(shibEmail);
 
-        String uin = credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_INSTITUTIONAL_IDENTIFIER));
-        if (uin == null) {
-            uin = credentials.getEmail();
-        }
-
-        // TODO: check to see if credentials is from basic login or shibboleth
-        // do not create new user from basic login credentials that have no user!
         if (user == null) {
-
             Role role = Role.ROLE_STUDENT;
-
-            if (credentials.getRole() == null) {
-                credentials.setRole(role.toString());
-            }
-
-            String shibEmail = credentials.getEmail();
 
             for (String email : admins) {
                 if (email.equals(shibEmail)) {
                     role = Role.ROLE_ADMIN;
-                    credentials.setRole(role.toString());
                 }
             }
 
-            user = userRepo.create(credentials.getEmail(), credentials.getFirstName(), credentials.getLastName(), role);
+            user = userRepo.create(shibEmail, credentials.getFirstName(), credentials.getLastName(), role);
 
-            user.setNetid(credentials.getNetid());
+            user.setNetid(shibNetid);
+            user.setMiddleName(shibMiddleName);
+            user.setOrcid(shibOrcid);
 
-            if (credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_BIRTH_YEAR)) != null) {
-                user.setBirthYear(Integer.parseInt(credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_BIRTH_YEAR))));
+            if (credentials.getAllCredentials().containsKey(shibValues.get(BIRTH_YEAR))) {
+                String shibBirthYearValue = credentials.getAllCredentials().get(shibValues.get(BIRTH_YEAR));
+                if (StringUtils.isNotEmpty(shibBirthYearValue)) {
+                    user.setBirthYear(Integer.parseInt(shibBirthYearValue));
+                }
             }
-            user.setMiddleName(credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_MIDDLE_NAME)));
-            user.setOrcid(credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_ORCID)));
-            user.setUsername(credentials.getEmail());
 
             user = userRepo.save(user);
         } else {
+            boolean isUserUpdated = false;
 
-            // TODO: update only if user properties does not match current credentials
-
-//DONT OVERWRITE WITH NULL VALUE
-//MORE WORK NEEDED
-            //user.setNetid(credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_INSTITUTIONAL_IDENTIFIER)));
-            if (credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_BIRTH_YEAR)) != null) {
-                user.setBirthYear(Integer.parseInt(credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_BIRTH_YEAR))));
+            if (StringUtils.isNotEmpty(shibNetid) && !user.getNetid().equals(shibNetid)) {
+                user.setNetid(shibNetid);
+                isUserUpdated = true;
             }
-            user.setMiddleName(credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_MIDDLE_NAME)));
-            user.setOrcid(credentials.getAllCredentials().get(shibValues.get(ConfigurationName.APPLICATION_AUTH_SHIB_ATTRIBUTE_ORCID)));
-            user.setUsername(credentials.getEmail());
 
-            user = userRepo.save(user);
+            if (credentials.getAllCredentials().containsKey(shibValues.get(BIRTH_YEAR))) {
+                String shibBirthYearValue = credentials.getAllCredentials().get(shibValues.get(BIRTH_YEAR));
+
+                if (StringUtils.isNotEmpty(shibBirthYearValue)) {
+                    int shibBirthYear = Integer.parseInt(shibBirthYearValue);
+                    if (shibBirthYear != user.getBirthYear()) {
+                        user.setBirthYear(shibBirthYear);
+                        isUserUpdated = true;
+                    }
+                }
+            }
+
+            if (StringUtils.isNotEmpty(shibMiddleName) && !user.getMiddleName().equals(shibMiddleName)) {
+                user.setMiddleName(shibMiddleName);
+                isUserUpdated = true;
+            }
+
+            if (StringUtils.isNotEmpty(shibOrcid) && !user.getOrcid().equals(shibOrcid)) {
+                user.setOrcid(shibOrcid);
+                isUserUpdated = true;
+            }
+
+            if (StringUtils.isNotEmpty(shibEmail) && !user.getUsername().equals(shibEmail)) {
+                user.setUsername(shibEmail);
+                isUserUpdated = true;
+            }
+
+            if (isUserUpdated) {
+                user = userRepo.save(user);
+            }
         }
 
         credentials.setRole(user.getRole().toString());
-        // TODO: is this correct? check for use of credentials uin
-        credentials.setUin(user.getUsername());
+
+        credentials.setNetid(user.getNetid());
 
         return user;
     }

--- a/src/main/java/org/tdl/vireo/model/User.java
+++ b/src/main/java/org/tdl/vireo/model/User.java
@@ -55,7 +55,7 @@ public class User extends AbstractWeaverUserDetails {
     private static final long serialVersionUID = -614285536644750464L;
 
     @JsonView(Views.Partial.class)
-    @Column(nullable = true)
+    @Column(nullable = true, unique = true)
     private String netid;
 
     @JsonView(Views.SubmissionList.class)

--- a/src/main/java/org/tdl/vireo/model/repo/UserRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/UserRepo.java
@@ -17,6 +17,8 @@ public interface UserRepo extends AbstractWeaverUserRepo<User>, UserRepoCustom {
 
     public User findByEmail(String email);
 
+    public User findByNetid(String netid);
+
     public List<User> findAllByRoleIn(List<IRole> role, Sort sort);
 
     public List<User> findAllByRoleIn(List<IRole> role, Pageable pageable);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -177,6 +177,9 @@ app:
   dataLoader:
     initialize: true
 
+  # org.tdl.vireo.auth.service.VireoUserCredentialsService
+  useNetIdAsIdentifier: false
+
 # edu.tamu.weaver.token.service.TokenService
 auth:
   security.jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -178,7 +178,7 @@ app:
     initialize: true
 
   # org.tdl.vireo.auth.service.VireoUserCredentialsService
-  useNetIdAsIdentifier: false
+  useNetidAsIdentifier: false
 
 # edu.tamu.weaver.token.service.TokenService
 auth:


### PR DESCRIPTION
When shibboleth attribute mapping is updated in the UI, the key stored in the configuration repo matches a Java string constant label, i.e. `APPLICATION_AUTH_SHIB_ATTRIBUTE_NETID`. The VireoUserCredentialsService was attempting to lookup shibboleth keys by the value of the Java constant, i.e. `auth.shib.attribute.netid`.

Here is where the Java constants are defined, https://github.com/TAMULib/Vireo/blob/sprint2-staging/src/main/java/org/tdl/vireo/config/constant/ConfigurationName.java#L166.

This PR respects the configuration repo which can be configured in the UI for shibboleth mappings. Also, did the TODOs.