### PR TITLE
Fix last action column text in batch export excel packager

### DIFF
--- a/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
+++ b/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
@@ -24,6 +24,7 @@ import org.tdl.vireo.model.Submission;
 import org.tdl.vireo.model.SubmissionListColumn;
 import org.tdl.vireo.model.export.ExcelExportPackage;
 import org.tdl.vireo.model.formatter.AbstractFormatter;
+import org.tdl.vireo.model.ActionLog;
 
 import edu.tamu.weaver.data.utility.EntityUtility;
 
@@ -111,6 +112,9 @@ public class ExcelPackager extends AbstractPackager<ExcelExportPackage> {
                         } else if (valueAsObject instanceof User){
                             User user = (User) valueAsObject;
                             value = user.getName().toString();
+                        } else if (valueAsObject instanceof ActionLog){
+                            ActionLog actionLog = (ActionLog) valueAsObject;
+                            value = actionLog.getEntry().toString();
                         } else {
                             value = valueAsObject.toString();
                         }


### PR DESCRIPTION
I believe I found why the `Last Event` column in the Batch Export (Excel) is giving that weird text like this `org.tdl.vireo.model.ActionLog@1234ab`. The `ExcelPackager` seems to not account for the `ActionLog` object type in its series of `else if` . Once I added that block and retrieved the actual action log entry, it's displaying correctly in the exported Excel.