### PR TITLE
Fix the submission date on the submission history page

### DIFF
--- a/src/main/webapp/app/views/submission/submissionHistory.html
+++ b/src/main/webapp/app/views/submission/submissionHistory.html
@@ -17,7 +17,7 @@
             <td title="'Status'">{{row.submissionStatus.name}}</td>
             <td title="'Document Title'">{{getDocumentTitle(row) || "No Title"}}</td>
             <td title="'Manuscript File Name'">{{getManuscriptFileName(row, "No Primary Document")}}</td>
-            <td title="'Date Submitted'">{{row.submissionDate || "Not Submitted" | date: M/d/yyyy}}</td>
+            <td title="'Date Submitted'">{{row.submissionDate || "Not Submitted" | date: M/d/yyyy : 'UTC'}}</td>
             <td title="'Assigned To'">{{row.assignee.settings.displayName || "Not Assigned"}}</td>
             <td title="'Actions'">
                 <button ng-if="row.submissionStatus.name === SubmissionStatuses.IN_PROGRESS" class="btn btn-danger" ng-click="confirmDelete(row)">Delete</button>


### PR DESCRIPTION
This is the same issue as the one we fixed last time on the left side pane where the displayed submission date is one day off. Needed to apply `: 'UTC'` here as well for the submission date on the submission history page. I've tested it on demos.